### PR TITLE
Fix attribute selector matching for values containing backslashes

### DIFF
--- a/src/js/matcher.js
+++ b/src/js/matcher.js
@@ -443,16 +443,19 @@ export const matchAttributeSelector = (ast, node, opt = {}) => {
   const { name: astIdentValue, value: astStringValue } = astValue ?? {};
   let attrValue;
   if (astIdentValue) {
+    // Ident values are not unescaped by css-tree, so we must unescape them
+    // (e.g. `\5c` hex escapes, `\n` character escapes).
     if (caseInsensitive) {
-      attrValue = astIdentValue.toLowerCase().replace(/\\(?!\\)/g, '');
+      attrValue = unescapeSelector(astIdentValue).toLowerCase();
     } else {
-      attrValue = astIdentValue.replace(/\\(?!\\)/g, '');
+      attrValue = unescapeSelector(astIdentValue);
     }
   } else if (astStringValue) {
+    // String values (quoted) are already unescaped by css-tree, so use as-is.
     if (caseInsensitive) {
-      attrValue = astStringValue.toLowerCase().replace(/\\(?!\\)/g, '');
+      attrValue = astStringValue.toLowerCase();
     } else {
-      attrValue = astStringValue.replace(/\\(?!\\)/g, '');
+      attrValue = astStringValue;
     }
   } else if (astStringValue === '') {
     attrValue = astStringValue;

--- a/src/js/parser.js
+++ b/src/js/parser.js
@@ -72,6 +72,13 @@ export const unescapeSelector = (selector = '') => {
       const item = arr[i];
       if (item === '' && i === l - 1) {
         selectorItems.push(U_FFFD);
+      } else if (item === '') {
+        // Empty segment at non-last position means \\ (escaped backslash)
+        selectorItems.push('\\');
+        i++; // skip the next segment which is the remainder after \\
+        if (i < l) {
+          selectorItems.push(arr[i]);
+        }
       } else {
         const hexExists = /^([\da-f]{1,6}\s?)/i.exec(item);
         if (hexExists) {

--- a/test/issues.test.js
+++ b/test/issues.test.js
@@ -1316,4 +1316,48 @@ describe('domSelector regression tests', () => {
       );
     });
   });
+
+  describe('attribute selector with hex-escaped backslash in value', () => {
+    let window;
+    beforeEach(() => {
+      const dom = jsdom('');
+      window = dom.window;
+    });
+    afterEach(() => {
+      window = null;
+    });
+
+    it('should match string value containing backslash via hex escape', () => {
+      const doc = new window.DOMParser().parseFromString(
+        '<div data-k="a\\b">content</div>',
+        'text/html'
+      );
+      const div = doc.querySelector('div');
+      // \5c is the CSS hex escape for backslash (U+005C)
+      const res = doc.querySelector('[data-k="a\\5c b"]');
+      assert.deepEqual(res, div, 'hex escape \\5c should match literal backslash');
+    });
+
+    it('should match ident value containing backslash via hex escape', () => {
+      const doc = new window.DOMParser().parseFromString(
+        '<div data-k="ab">content</div>',
+        'text/html'
+      );
+      const div = doc.querySelector('div');
+      // \61 is hex for 'a', \62 is hex for 'b'
+      const res = doc.querySelector('[data-k=\\61 \\62]');
+      assert.deepEqual(res, div, 'hex escapes in ident value should match');
+    });
+
+    it('should match string value with escaped backslash (double backslash)', () => {
+      const doc = new window.DOMParser().parseFromString(
+        '<div data-k="a\\b">content</div>',
+        'text/html'
+      );
+      const div = doc.querySelector('div');
+      // In CSS, \\ is an escaped backslash
+      const res = doc.querySelector('[data-k="a\\\\b"]');
+      assert.deepEqual(res, div, 'escaped backslash should match literal backslash');
+    });
+  });
 });


### PR DESCRIPTION
The regex `replace(/\\(?!\\)/g, '')` in matchAttributeSelector was stripping literal backslash characters from attribute values after css-tree had already unescaped them. For string values (quoted), css-tree fully unescapes hex escapes like `\5c` into their character equivalents, so no further processing is needed. For ident values (unquoted), css-tree leaves escapes intact, so `unescapeSelector` should be used instead of the naive regex.

This caused selectors like `[data-k="a\5c b"]` and `[data-k="a\\b"]` to fail matching elements whose attribute value contained a literal backslash.