### PR TITLE
Fix class selector fast path for DocumentFragment

### DIFF
--- a/src/js/nwsapi.js
+++ b/src/js/nwsapi.js
@@ -617,7 +617,9 @@ export class Nwsapi {
       }
       return arr;
     }
-    return [];
+    return this._byTag('*', context).filter(node =>
+      node.classList.contains(cls)
+    );
   }
 
   /**

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -2796,6 +2796,35 @@ describe('patched JSDOM', () => {
       assert.deepEqual(res, [li1, li3, li5], 'result');
     });
 
+    it('should get matched node by class name', () => {
+      const frag = document.createDocumentFragment();
+      const div1 = document.createElement('div');
+      const div2 = document.createElement('div');
+      const ul1 = document.createElement('ul');
+      const li1 = document.createElement('li');
+      const li2 = document.createElement('li');
+      const li3 = document.createElement('li');
+      const li4 = document.createElement('li');
+      const li5 = document.createElement('li');
+      div1.id = 'div1';
+      div2.id = 'div2';
+      ul1.id = 'ul1';
+      li1.id = 'li1';
+      li2.id = 'li2';
+      li3.id = 'li3';
+      li4.id = 'li4';
+      li5.id = 'li5';
+      ul1.append(li1, li2, li3, li4, li5);
+      div2.appendChild(ul1);
+      div1.appendChild(div2);
+      frag.appendChild(div1);
+      div1.classList.add('foo');
+      ul1.classList.add('bar');
+      li3.classList.add('baz');
+      const res = frag.querySelectorAll('.baz');
+      assert.deepEqual(res, [li3], 'result');
+    });
+
     it('should not match', () => {
       const frag = document.createDocumentFragment();
       const div1 = document.createElement('div');


### PR DESCRIPTION
Fix `DocumentFragment.querySelectorAll()` for selectors whose optimized fast path is class-based.

The internal `Nwsapi._byClass()` helper returned an empty array when the context did not expose `getElementsByClassName()`. `DocumentFragment` has no such method, so selectors like `.baz` produced no candidates even when matching descendants existed.

Fall back to traversing all descendant elements via `_byTag("*", context)` and filtering by `classList.contains()`, matching the existing fallback style used for tag lookups.

Adds a regression test for `DocumentFragment.querySelectorAll(".baz")`.

Regression introduced by d8fa27e5552786075fd115b7a50bc48ae584eef3.