### PR TITLE
Replace generational-cache with lru-cache

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,10 @@
       "version": "8.2.0",
       "license": "MIT",
       "dependencies": {
-        "@asamuzakjp/generational-cache": "^3.0.1",
         "bidi-js": "^1.0.3",
         "css-tree": "^3.2.1",
-        "is-potential-custom-element-name": "^1.0.1"
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.5.2"
       },
       "devDependencies": {
         "@types/css-tree": "^2.3.11",
@@ -102,15 +102,6 @@
       "license": "MIT",
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
-      }
-    },
-    "node_modules/@asamuzakjp/generational-cache": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-3.0.1.tgz",
-      "integrity": "sha512-dI+Zi9yaDkBZpAgXxRowS6rJY4s4mg55XxZiSQSgoVya4vLKABv5+T+7+IHFC4I5LuC8PRfkQkDhXnvmMTC0Tg==",
-      "license": "MIT",
-      "engines": {
-        "node": "^22.13.0 || >=24.0.0"
       }
     },
     "node_modules/@asamuzakjp/nwsapi": {
@@ -386,9 +377,9 @@
       "license": "MIT"
     },
     "node_modules/@eslint/config-array/node_modules/brace-expansion": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2738,9 +2729,9 @@
       "license": "MIT"
     },
     "node_modules/eslint/node_modules/brace-expansion": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4262,10 +4253,9 @@
       }
     },
     "node_modules/lru-cache": {
-      "version": "11.3.5",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
-      "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
-      "dev": true,
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"

--- a/package.json
+++ b/package.json
@@ -25,10 +25,10 @@
     "./package.json": "./package.json"
   },
   "dependencies": {
-    "@asamuzakjp/generational-cache": "^3.0.1",
     "bidi-js": "^1.0.3",
     "css-tree": "^3.2.1",
-    "is-potential-custom-element-name": "^1.0.1"
+    "is-potential-custom-element-name": "^1.0.1",
+    "lru-cache": "^11.5.2"
   },
   "devDependencies": {
     "@types/css-tree": "^2.3.11",

--- a/src/index.js
+++ b/src/index.js
@@ -6,7 +6,7 @@
  */
 
 /* import */
-import { GenerationalCache } from '@asamuzakjp/generational-cache';
+import { LRUCache } from 'lru-cache';
 import { Finder } from './js/finder.js';
 import { Nwsapi } from './js/nwsapi.js';
 import { extractSubjectsAst } from './js/parser.js';
@@ -26,7 +26,7 @@ import {
   TARGET_LINEAL,
   TARGET_SELF
 } from './js/constant.js';
-const CACHE_SIZE = 2048;
+const CACHE_SIZE = 4096;
 
 /* regexp */
 const REG_SELECTOR = /[[\]():\\"'`]/;
@@ -60,11 +60,11 @@ export class DOMSelector {
     this.#window = window;
     this.#document = document ?? window.document;
     this.#idlUtils = idlUtils;
-    this.#cache = new GenerationalCache(cacheSize ?? CACHE_SIZE, {
-      strictvalidate: false
+    this.#cache = new LRUCache({
+      max: cacheSize ?? CACHE_SIZE
     });
     this.#finder = new Finder(this.#window);
-    this.#nwsapi = new Nwsapi(this.#window, this.#document);
+    this.#nwsapi = new Nwsapi(this.#window, this.#document, cacheSize);
   }
 
   /**

--- a/src/js/nwsapi.js
+++ b/src/js/nwsapi.js
@@ -5,7 +5,7 @@
  */
 
 /* import */
-import { GenerationalCache } from '@asamuzakjp/generational-cache';
+import { LRUCache } from 'lru-cache';
 import { isContentEditable } from './utility.js';
 
 /* constants */
@@ -465,13 +465,12 @@ export class Nwsapi {
   constructor(window, document, cacheSize = CACHE_SIZE) {
     this.#window = window;
     const cacheOpt = {
-      cacheFunction: true,
-      strictValidate: false
+      max: cacheSize
     };
-    this.#matchLambdas = new GenerationalCache(cacheSize, cacheOpt);
-    this.#selectLambdas = new GenerationalCache(cacheSize, cacheOpt);
-    this.#matchResolvers = new GenerationalCache(cacheSize, cacheOpt);
-    this.#selectResolvers = new GenerationalCache(cacheSize, cacheOpt);
+    this.#matchLambdas = new LRUCache(cacheOpt);
+    this.#selectLambdas = new LRUCache(cacheOpt);
+    this.#matchResolvers = new LRUCache(cacheOpt);
+    this.#selectResolvers = new LRUCache(cacheOpt);
     this.#nthChildState = {
       idx: 0,
       len: 0,

--- a/test/selector.test.js
+++ b/test/selector.test.js
@@ -787,6 +787,16 @@ describe('selector static analysis and validation', () => {
         false,
         'invalid deeply nested logic'
       );
+      assert.strictEqual(
+        func('p:not(:is(:not(.content))):not(.foo)', TARGET_ALL),
+        false,
+        'invalid deeply nested logic'
+      );
+      assert.strictEqual(
+        func('p:not(:is(:not(.content))):not(.foo)', TARGET_SELF),
+        false,
+        'invalid deeply nested logic'
+      );
     });
 
     it('should get false for unsupported pseudo-classes in fast-path', () => {


### PR DESCRIPTION
Swap @asamuzakjp/generational-cache for lru-cache across the project. Increase default CACHE_SIZE to 4096 and forward cacheSize to Nwsapi. These changes adjust cache configuration and behavior while keeping APIs compatible for the project's usage.