### PR TITLE
Fix querySelector() with a compound selector and a duplicated id

### DIFF
--- a/src/js/finder.js
+++ b/src/js/finder.js
@@ -414,17 +414,18 @@ export class Finder extends Evaluator {
     ) {
       const [leaf] = leaves;
       const node = this.root.getElementById(leaf.name);
-      const nodes = [];
-      if (node) {
-        if (filterLeaves.length) {
-          if (this.matchLeaves(filterLeaves, node, this.matchOpts)) {
-            nodes.push(node);
-          }
-        } else {
-          nodes.push(node);
-        }
+      /*
+       * getElementById() answers with the first element carrying the id. For a compound
+       * selector that element may fail the remaining leaves while a later element sharing the
+       * id still matches, so the shortcut can only conclude the search when it succeeds.
+       */
+      if (!filterLeaves.length) {
+        const nodes = node ? [node] : [];
+        return { compound, filtered: nodes.length > 0, nodes, pending: false };
       }
-      return { compound, filtered: nodes.length > 0, nodes, pending: false };
+      if (node && this.matchLeaves(filterLeaves, node, this.matchOpts)) {
+        return { compound, filtered: true, nodes: [node], pending: false };
+      }
     }
     return this.#fallbackToWalkerResult(leaves, targetType, precede, compound);
   };

--- a/test/issues.test.js
+++ b/test/issues.test.js
@@ -1947,4 +1947,63 @@ describe('domSelector regression tests', () => {
       );
     });
   });
+  describe('#302 - https://github.com/asamuzaK/domSelector/issues/302', () => {
+    const html = `
+      <object id="foo"></object>
+      <object id="foo"></object>
+      <img id="foo">
+      <div id="bar"><span>baz</span></div>
+      <b id="bar">qux</b>
+    `;
+
+    it('should match a later element sharing the id', () => {
+      const { document } = jsdom(html).window;
+      const img = document.getElementsByTagName('img')[0];
+      assert.deepEqual(document.querySelector('img#foo'), img, 'type and id');
+      assert.deepEqual(
+        document.querySelector('#foo:not(object)'),
+        img,
+        'negated type'
+      );
+    });
+
+    it('should stay consistent with querySelectorAll() and matches()', () => {
+      const { document } = jsdom(html).window;
+      const img = document.getElementsByTagName('img')[0];
+      assert.deepEqual(
+        document.querySelectorAll('img#foo'),
+        [img],
+        'querySelectorAll()'
+      );
+      assert.strictEqual(img.matches('img#foo'), true, 'matches()');
+      assert.deepEqual(
+        document.querySelector('img#foo'),
+        img,
+        'querySelector()'
+      );
+    });
+
+    it('should still answer with the first element for a plain id selector', () => {
+      const { document } = jsdom(html).window;
+      const [firstObject] = document.getElementsByTagName('object');
+      assert.deepEqual(document.querySelector('#foo'), firstObject, 'plain id');
+      assert.deepEqual(
+        document.querySelector('object#foo'),
+        firstObject,
+        'first element matches'
+      );
+    });
+
+    it('should return null when nothing sharing the id matches', () => {
+      const { document } = jsdom(html).window;
+      assert.deepEqual(document.querySelector('p#foo'), null, 'no match');
+      assert.deepEqual(document.querySelector('#nope'), null, 'unknown id');
+    });
+
+    it('should match a later element sharing the id of an ancestor', () => {
+      const { document } = jsdom(html).window;
+      const b = document.getElementsByTagName('b')[0];
+      assert.deepEqual(document.querySelector('b#bar'), b, 'type and id');
+    });
+  });
 });


### PR DESCRIPTION
Fixes #302.

`getElementById()` answers with the *first* element carrying an id. The `TARGET_FIRST` shortcut in `findEntryNodesForId()` ran the remaining leaves of a compound selector against that element and, when they failed, returned an empty result instead of falling through to the walker — so a later element sharing the id was never considered.

```js
const { window } = new JSDOM('<object id="foo"></object><object id="foo"></object><img id="foo">');
const sel = new DOMSelector(window);
const doc = window.document;

sel.querySelectorAll('img#foo', doc).length;                              // 1
sel.matches('img#foo', doc.getElementsByTagName('img')[0]);               // true
sel.querySelector('img#foo', doc);
// before: null
// after:  the img, which is what Chrome and Firefox return
```

`#foo:not(object)` was affected the same way.

### The change

The shortcut now only concludes the search when it succeeds:

- no filter leaves — plain `#id` — unchanged, still one `getElementById()` call;
- filter leaves and the first candidate matches — unchanged, still no traversal;
- filter leaves and the first candidate does not match — falls through to `fallbackToWalkerResult()`, which is the only case that got slower, and only for documents with duplicate ids.

So the fast path is preserved for every valid-HTML case; the cost is paid only where the old code returned a wrong answer.

### Tests

Added a `#302` block to `test/issues.test.js` covering: a later element matching by type and by `:not()`, agreement between `querySelector()`, `querySelectorAll()` and `matches()`, the plain-id and first-element-matches cases still answering with the first element, `null` when nothing sharing the id matches, and an id shared between an ancestor and a later sibling.

Verified the new tests fail against `main` (3 failures) and pass with the change. Full suite: 2254 passing, 0 failing. ESLint clean.

### How I ran into it

jsdom uses this package as its selector engine, and this is currently blocking a web-platform-test there — `nameditem-img-name-added-cached-list.html` calls `document.querySelector("img#foo")` on a document with two earlier `object#foo` elements (jsdom/jsdom#4203).
