### PR TITLE
perf(jsdom): Restore matches fast path

### DIFF
--- a/benchmark/bench-testing-library.js
+++ b/benchmark/bench-testing-library.js
@@ -62,6 +62,18 @@ root.appendChild(targetRole);
 const totalElements = document.querySelectorAll('*').length;
 
 const domSelector = new DOMSelector(window);
+const documentImpl = {
+  compatMode: document.compatMode,
+  contentType: document.contentType,
+  nodeType: document.nodeType
+};
+const jsdomSelector = new DOMSelector(window, documentImpl, {
+  idlUtils: {
+    implForWrapper: node => (node === document ? documentImpl : node),
+    wrapperForImpl: node => node
+  }
+});
+const implicitRoleCandidates = [...document.querySelectorAll('input')];
 
 console.log(`=======================================`);
 console.log(`DOMSelector Testing Library Queries Benchmark`);
@@ -110,6 +122,14 @@ group(`Testing Library Typical Queries (Element)`, () => {
 
   bench(`[title="target-title"], svg title`, () => {
     domSelector.querySelectorAll('[title="target-title"], svg title', root);
+  });
+});
+
+group(`Testing Library Implicit Role Matching (jsdom)`, () => {
+  bench(`input:not([type]):not([list])`, () => {
+    for (const candidate of implicitRoleCandidates) {
+      jsdomSelector.matches('input:not([type]):not([list])', candidate);
+    }
   });
 });
 

--- a/benchmark/bench-testing-library.js
+++ b/benchmark/bench-testing-library.js
@@ -3,6 +3,7 @@
  */
 import { run, bench, group } from 'mitata';
 import { JSDOM } from 'jsdom';
+import idlUtils from 'jsdom/lib/generated/idl/utils.js';
 import { DOMSelector } from '../src/index.js';
 
 const DEPTH = 4;
@@ -62,18 +63,13 @@ root.appendChild(targetRole);
 const totalElements = document.querySelectorAll('*').length;
 
 const domSelector = new DOMSelector(window);
-const documentImpl = {
-  compatMode: document.compatMode,
-  contentType: document.contentType,
-  nodeType: document.nodeType
-};
+const documentImpl = idlUtils.implForWrapper(document);
 const jsdomSelector = new DOMSelector(window, documentImpl, {
-  idlUtils: {
-    implForWrapper: node => (node === document ? documentImpl : node),
-    wrapperForImpl: node => node
-  }
+  idlUtils
 });
-const implicitRoleCandidates = [...document.querySelectorAll('input')];
+const implicitRoleCandidates = [...document.querySelectorAll('input')].map(
+  idlUtils.implForWrapper
+);
 
 console.log(`=======================================`);
 console.log(`DOMSelector Testing Library Queries Benchmark`);

--- a/src/index.js
+++ b/src/index.js
@@ -105,9 +105,11 @@ export class DOMSelector {
    */
   #tryNwsapi = (selector, node, targetType, callback, isCheck = false) => {
     const document = node.ownerDocument;
+    // jsdom passes an internal document to the constructor but wraps entry nodes.
     if (
       node.isConnected &&
-      document === this.#document &&
+      (document === this.#document ||
+        this.#idlUtils?.implForWrapper?.(document) === this.#document) &&
       document.contentType === 'text/html' &&
       document.documentElement
     ) {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -5,6 +5,7 @@
 /* api */
 import { strict as assert } from 'node:assert';
 import { JSDOM } from 'jsdom';
+import idlUtils from 'jsdom/lib/generated/idl/utils.js';
 import { afterEach, beforeEach, describe, it } from 'mocha';
 import sinon from 'sinon';
 import * as cssTree from 'css-tree';
@@ -921,23 +922,19 @@ describe('DOMSelector', () => {
       assert.deepEqual(res, true, 'result');
     });
 
-    it('should compare wrapped document using idlUtils', () => {
+    it('should use Fast Path with jsdom implementation nodes', () => {
       const node = document.getElementById('li2');
-      const documentImpl = {
-        compatMode: 'CSS1Compat',
-        contentType: 'text/html',
-        nodeType: 9
-      };
-      const nodeImpl = {};
-      const wrapperForImpl = sinon.stub();
-      wrapperForImpl.withArgs(nodeImpl).returns(node);
-      const implForWrapper = sinon.stub();
-      implForWrapper.withArgs(document).returns(documentImpl);
+      const documentImpl = idlUtils.implForWrapper(document);
+      const nodeImpl = idlUtils.implForWrapper(node);
+      // The Finder fallback walks parentNode while resolving the root.
+      const parentNodeGetter = sinon.spy(node, 'parentNode', ['get']);
       const domSelector = new DOMSelector(window, documentImpl, {
-        idlUtils: { implForWrapper, wrapperForImpl }
+        idlUtils
       });
       const res = domSelector.matches('li', nodeImpl);
-      assert.strictEqual(implForWrapper.calledOnceWithExactly(document), true);
+      const parentNodeCallCount = parentNodeGetter.get.callCount;
+      parentNodeGetter.get.restore();
+      assert.strictEqual(parentNodeCallCount, 0, 'Fast Path');
       assert.strictEqual(res, true, 'result');
     });
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -921,6 +921,26 @@ describe('DOMSelector', () => {
       assert.deepEqual(res, true, 'result');
     });
 
+    it('should compare wrapped document using idlUtils', () => {
+      const node = document.getElementById('li2');
+      const documentImpl = {
+        compatMode: 'CSS1Compat',
+        contentType: 'text/html',
+        nodeType: 9
+      };
+      const nodeImpl = {};
+      const wrapperForImpl = sinon.stub();
+      wrapperForImpl.withArgs(nodeImpl).returns(node);
+      const implForWrapper = sinon.stub();
+      implForWrapper.withArgs(document).returns(documentImpl);
+      const domSelector = new DOMSelector(window, documentImpl, {
+        idlUtils: { implForWrapper, wrapperForImpl }
+      });
+      const res = domSelector.matches('li', nodeImpl);
+      assert.strictEqual(implForWrapper.calledOnceWithExactly(document), true);
+      assert.strictEqual(res, true, 'result');
+    });
+
     it('should return false for pseudo-element via matches()', () => {
       const wrapperForImpl = sinon.stub().callsFake(node => node);
       const i = wrapperForImpl.callCount;


### PR DESCRIPTION
jsdom has two objects for the same document: its internal object and the public `document` wrapper. DOMSelector was comparing one to the other while deciding whether it could use its fast matcher. They can never be `===`, so every supported `matches()` call from jsdom used the slow fallback.

This comes from how DOMSelector was added to jsdom in [jsdom/jsdom#3854](https://github.com/jsdom/jsdom/pull/3854), combined with the node wrapping cleanup in [#296](https://github.com/asamuzaK/domSelector/pull/296).

This change treats the wrapper and internal object as the same document during that check. The selector safety filter and slow fallback stay unchanged.

## Benchmarks

| Case | Before | After | Change |
|---|---:|---:|---:|
| `input:not([type]):not([list])` across 1,171 jsdom inputs | 5.08 ms | 0.55 ms | 89% less time |
| `getByRole('button')`, 300 sections nested 20 levels | 26.58 ms | 15.35 ms | 42% less time |
