### PR TITLE
perf(jsdom): Speed up simple attribute presence queries

### DIFF
--- a/benchmark/bench-testing-library.js
+++ b/benchmark/bench-testing-library.js
@@ -83,6 +83,10 @@ group(`Testing Library Typical Queries (document)`, () => {
     domSelector.querySelectorAll('[data-testid]', document);
   });
 
+  bench(`[title]`, () => {
+    domSelector.querySelectorAll('[title]', document);
+  });
+
   bench(`[data-testid="target-test-id"]`, () => {
     domSelector.querySelectorAll('[data-testid="target-test-id"]', document);
   });
@@ -109,6 +113,10 @@ group(`Testing Library Typical Queries (Element)`, () => {
     domSelector.querySelectorAll('[data-testid]', root);
   });
 
+  bench(`[title]`, () => {
+    domSelector.querySelectorAll('[title]', root);
+  });
+
   bench(`[data-testid="target-test-id"]`, () => {
     domSelector.querySelectorAll('[data-testid="target-test-id"]', root);
   });
@@ -133,6 +141,10 @@ group(`Testing Library Typical Queries (Element)`, () => {
 group(`Testing Library Implicit Role Matching (jsdom)`, () => {
   bench(`[data-testid]`, () => {
     jsdomSelector.querySelectorAll('[data-testid]', rootImpl);
+  });
+
+  bench(`[title]`, () => {
+    jsdomSelector.querySelectorAll('[title]', rootImpl);
   });
 
   bench(`input:not([type]):not([list])`, () => {

--- a/benchmark/bench-testing-library.js
+++ b/benchmark/bench-testing-library.js
@@ -67,6 +67,7 @@ const documentImpl = idlUtils.implForWrapper(document);
 const jsdomSelector = new DOMSelector(window, documentImpl, {
   idlUtils
 });
+const rootImpl = idlUtils.implForWrapper(root);
 const implicitRoleCandidates = [...document.querySelectorAll('input')].map(
   idlUtils.implForWrapper
 );
@@ -78,6 +79,10 @@ console.log(`Total Elements in Document: ${totalElements}`);
 console.log(`=======================================`);
 
 group(`Testing Library Typical Queries (document)`, () => {
+  bench(`[data-testid]`, () => {
+    domSelector.querySelectorAll('[data-testid]', document);
+  });
+
   bench(`[data-testid="target-test-id"]`, () => {
     domSelector.querySelectorAll('[data-testid="target-test-id"]', document);
   });
@@ -100,6 +105,10 @@ group(`Testing Library Typical Queries (document)`, () => {
 });
 
 group(`Testing Library Typical Queries (Element)`, () => {
+  bench(`[data-testid]`, () => {
+    domSelector.querySelectorAll('[data-testid]', root);
+  });
+
   bench(`[data-testid="target-test-id"]`, () => {
     domSelector.querySelectorAll('[data-testid="target-test-id"]', root);
   });
@@ -122,6 +131,10 @@ group(`Testing Library Typical Queries (Element)`, () => {
 });
 
 group(`Testing Library Implicit Role Matching (jsdom)`, () => {
+  bench(`[data-testid]`, () => {
+    jsdomSelector.querySelectorAll('[data-testid]', rootImpl);
+  });
+
   bench(`input:not([type]):not([list])`, () => {
     for (const candidate of implicitRoleCandidates) {
       jsdomSelector.matches('input:not([type]):not([list])', candidate);

--- a/src/index.js
+++ b/src/index.js
@@ -15,14 +15,16 @@ import {
   filterSelector,
   isSupportedAST
 } from './js/selector.js';
-import { collectAllDescendants, getType, isHTMLElement } from './js/utility.js';
+import {
+  collectAllDescendants,
+  findBySimpleAttribute,
+  getType
+} from './js/utility.js';
 
 /* constants */
 import {
-  DOCUMENT_FRAGMENT_NODE,
   DOCUMENT_NODE,
   ELEMENT_NODE,
-  SHOW_ELEMENT,
   TARGET_ALL,
   TARGET_FIRST,
   TARGET_LINEAL,
@@ -33,34 +35,6 @@ const CACHE_SIZE = 4096;
 /* regexp */
 const REG_SELECTOR = /[[\]():\\"'`]/;
 const REG_UNIVERSAL = /^(?:\*\|)?\*$/;
-const REG_SIMPLE_ATTRIBUTE = /^\[([a-z][a-z0-9_-]*)\]$/;
-
-/**
- * Tests whether an element has an attribute with the given local name.
- * @param {Element} node - The element to test.
- * @param {string} name - The lower-case attribute local name.
- * @returns {boolean} `true` if the attribute is present.
- */
-const hasAttributeLocalName = (node, name) => {
-  if (node.hasAttribute(name)) {
-    return true;
-  }
-  const names = node.getAttributeNames();
-  for (let i = 0; i < names.length; i++) {
-    const itemName = names[i];
-    const colonIndex = itemName.indexOf(':');
-    if (colonIndex > -1) {
-      const localName = itemName.slice(colonIndex + 1);
-      if (
-        localName === name ||
-        (isHTMLElement(node) && localName.toLowerCase() === name)
-      ) {
-        return true;
-      }
-    }
-  }
-  return false;
-};
 
 /**
  * @typedef {object} CheckResult
@@ -175,51 +149,6 @@ export class DOMSelector {
     } catch (e) {
       return this.#finder.onError(e, opt);
     }
-  };
-
-  /**
-   * Finds descendants for simple attribute-presence selectors. More complex
-   * selectors continue through Finder.
-   * @private
-   * @param {string} selector - The CSS selector to match against.
-   * @param {Document|DocumentFragment|Element} node - The node to find within.
-   * @returns {?Array<Element>} Matching elements, or `null` when this fast path does not apply.
-   */
-  #findBySimpleAttribute = (selector, node) => {
-    if (typeof selector !== 'string') {
-      return null;
-    }
-    const match = REG_SIMPLE_ATTRIBUTE.exec(selector);
-    if (!match) {
-      return null;
-    }
-    const name = match[1];
-    // Finder deliberately excludes xml:lang from unprefixed [lang].
-    if (name === 'lang') {
-      return null;
-    }
-    const { nodeType } = node;
-    const isQueryContext =
-      nodeType === DOCUMENT_NODE ||
-      nodeType === DOCUMENT_FRAGMENT_NODE ||
-      nodeType === ELEMENT_NODE;
-    if (!isQueryContext) {
-      return null;
-    }
-    const document = nodeType === DOCUMENT_NODE ? node : node.ownerDocument;
-    if (document.contentType !== 'text/html') {
-      return null;
-    }
-    const walker = document.createTreeWalker(node, SHOW_ELEMENT);
-    const nodes = [];
-    let descendant = walker.nextNode();
-    while (descendant) {
-      if (hasAttributeLocalName(descendant, name)) {
-        nodes.push(descendant);
-      }
-      descendant = walker.nextNode();
-    }
-    return nodes;
   };
 
   /**
@@ -447,7 +376,7 @@ export class DOMSelector {
         node.nodeType === DOCUMENT_NODE ? node : node.ownerDocument;
       return collectAllDescendants(node, document);
     }
-    const fastNodes = this.#findBySimpleAttribute(selector, node);
+    const fastNodes = findBySimpleAttribute(selector, node);
     if (fastNodes !== null) {
       return fastNodes;
     }

--- a/src/index.js
+++ b/src/index.js
@@ -20,7 +20,9 @@ import { collectAllDescendants, getType } from './js/utility.js';
 /* constants */
 import {
   DOCUMENT_NODE,
+  DOCUMENT_FRAGMENT_NODE,
   ELEMENT_NODE,
+  SHOW_ELEMENT,
   TARGET_ALL,
   TARGET_FIRST,
   TARGET_LINEAL,
@@ -31,6 +33,28 @@ const CACHE_SIZE = 4096;
 /* regexp */
 const REG_SELECTOR = /[[\]():\\"'`]/;
 const REG_UNIVERSAL = /^(?:\*\|)?\*$/;
+const REG_SIMPLE_DATA_ATTRIBUTE = /^\[(data-[a-z0-9_-]+)\]$/;
+
+/**
+ * Tests whether an element has an attribute with the given local name.
+ * @param {Element} node - The element to test.
+ * @param {string} name - The lower-case attribute local name.
+ * @returns {boolean} `true` if the attribute is present.
+ */
+const hasAttributeLocalName = (node, name) => {
+  if (node.hasAttribute(name)) {
+    return true;
+  }
+  const names = node.getAttributeNames();
+  for (let i = 0; i < names.length; i++) {
+    const itemName = names[i];
+    const colonIndex = itemName.indexOf(':');
+    if (colonIndex > -1 && itemName.slice(colonIndex + 1) === name) {
+      return true;
+    }
+  }
+  return false;
+};
 
 /**
  * @typedef {object} CheckResult
@@ -145,6 +169,45 @@ export class DOMSelector {
     } catch (e) {
       return this.#finder.onError(e, opt);
     }
+  };
+
+  /**
+   * Finds descendants for the simple data attribute-presence selectors used by
+   * Testing Library. More complex selectors continue through Finder.
+   * @private
+   * @param {string} selector - The CSS selector to match against.
+   * @param {Document|DocumentFragment|Element} node - The node to find within.
+   * @returns {?Array<Element>} Matching elements, or `null` when this fast path does not apply.
+   */
+  #findBySimpleDataAttribute = (selector, node) => {
+    if (typeof selector !== 'string') {
+      return null;
+    }
+    const match = REG_SIMPLE_DATA_ATTRIBUTE.exec(selector);
+    if (
+      !match ||
+      (node.nodeType !== DOCUMENT_NODE &&
+        node.nodeType !== DOCUMENT_FRAGMENT_NODE &&
+        node.nodeType !== ELEMENT_NODE)
+    ) {
+      return null;
+    }
+    const document =
+      node.nodeType === DOCUMENT_NODE ? node : node.ownerDocument;
+    if (document.contentType !== 'text/html') {
+      return null;
+    }
+    const name = match[1];
+    const walker = document.createTreeWalker(node, SHOW_ELEMENT);
+    const nodes = [];
+    let descendant = walker.nextNode();
+    while (descendant) {
+      if (hasAttributeLocalName(descendant, name)) {
+        nodes.push(descendant);
+      }
+      descendant = walker.nextNode();
+    }
+    return nodes;
   };
 
   /**
@@ -371,6 +434,10 @@ export class DOMSelector {
       const document =
         node.nodeType === DOCUMENT_NODE ? node : node.ownerDocument;
       return collectAllDescendants(node, document);
+    }
+    const fastNodes = this.#findBySimpleDataAttribute(selector, node);
+    if (fastNodes) {
+      return fastNodes;
     }
     const nodes = this.#findNodes(selector, node, opt, TARGET_ALL);
     if (nodes && nodes.size) {

--- a/src/index.js
+++ b/src/index.js
@@ -19,8 +19,8 @@ import { collectAllDescendants, getType, isHTMLElement } from './js/utility.js';
 
 /* constants */
 import {
-  DOCUMENT_NODE,
   DOCUMENT_FRAGMENT_NODE,
+  DOCUMENT_NODE,
   ELEMENT_NODE,
   SHOW_ELEMENT,
   TARGET_ALL,
@@ -46,17 +46,15 @@ const hasAttributeLocalName = (node, name) => {
     return true;
   }
   const names = node.getAttributeNames();
-  let isHTML;
   for (let i = 0; i < names.length; i++) {
     const itemName = names[i];
     const colonIndex = itemName.indexOf(':');
     if (colonIndex > -1) {
       const localName = itemName.slice(colonIndex + 1);
-      if (localName === name) {
-        return true;
-      }
-      isHTML ??= isHTMLElement(node);
-      if (isHTML && localName.toLowerCase() === name) {
+      if (
+        localName === name ||
+        (isHTMLElement(node) && localName.toLowerCase() === name)
+      ) {
         return true;
       }
     }
@@ -192,22 +190,26 @@ export class DOMSelector {
       return null;
     }
     const match = REG_SIMPLE_ATTRIBUTE.exec(selector);
-    if (
-      !match ||
-      // Finder deliberately excludes xml:lang from unprefixed [lang].
-      match[1] === 'lang' ||
-      (node.nodeType !== DOCUMENT_NODE &&
-        node.nodeType !== DOCUMENT_FRAGMENT_NODE &&
-        node.nodeType !== ELEMENT_NODE)
-    ) {
-      return null;
-    }
-    const document =
-      node.nodeType === DOCUMENT_NODE ? node : node.ownerDocument;
-    if (document.contentType !== 'text/html') {
+    if (!match) {
       return null;
     }
     const name = match[1];
+    // Finder deliberately excludes xml:lang from unprefixed [lang].
+    if (name === 'lang') {
+      return null;
+    }
+    const { nodeType } = node;
+    const isQueryContext =
+      nodeType === DOCUMENT_NODE ||
+      nodeType === DOCUMENT_FRAGMENT_NODE ||
+      nodeType === ELEMENT_NODE;
+    if (!isQueryContext) {
+      return null;
+    }
+    const document = nodeType === DOCUMENT_NODE ? node : node.ownerDocument;
+    if (document.contentType !== 'text/html') {
+      return null;
+    }
     const walker = document.createTreeWalker(node, SHOW_ELEMENT);
     const nodes = [];
     let descendant = walker.nextNode();
@@ -446,7 +448,7 @@ export class DOMSelector {
       return collectAllDescendants(node, document);
     }
     const fastNodes = this.#findBySimpleAttribute(selector, node);
-    if (fastNodes) {
+    if (fastNodes !== null) {
       return fastNodes;
     }
     const nodes = this.#findNodes(selector, node, opt, TARGET_ALL);

--- a/src/index.js
+++ b/src/index.js
@@ -15,7 +15,7 @@ import {
   filterSelector,
   isSupportedAST
 } from './js/selector.js';
-import { collectAllDescendants, getType } from './js/utility.js';
+import { collectAllDescendants, getType, isHTMLElement } from './js/utility.js';
 
 /* constants */
 import {
@@ -33,7 +33,7 @@ const CACHE_SIZE = 4096;
 /* regexp */
 const REG_SELECTOR = /[[\]():\\"'`]/;
 const REG_UNIVERSAL = /^(?:\*\|)?\*$/;
-const REG_SIMPLE_DATA_ATTRIBUTE = /^\[(data-[a-z0-9_-]+)\]$/;
+const REG_SIMPLE_ATTRIBUTE = /^\[([a-z][a-z0-9_-]*)\]$/;
 
 /**
  * Tests whether an element has an attribute with the given local name.
@@ -46,11 +46,19 @@ const hasAttributeLocalName = (node, name) => {
     return true;
   }
   const names = node.getAttributeNames();
+  let isHTML;
   for (let i = 0; i < names.length; i++) {
     const itemName = names[i];
     const colonIndex = itemName.indexOf(':');
-    if (colonIndex > -1 && itemName.slice(colonIndex + 1) === name) {
-      return true;
+    if (colonIndex > -1) {
+      const localName = itemName.slice(colonIndex + 1);
+      if (localName === name) {
+        return true;
+      }
+      isHTML ??= isHTMLElement(node);
+      if (isHTML && localName.toLowerCase() === name) {
+        return true;
+      }
     }
   }
   return false;
@@ -172,20 +180,22 @@ export class DOMSelector {
   };
 
   /**
-   * Finds descendants for the simple data attribute-presence selectors used by
-   * Testing Library. More complex selectors continue through Finder.
+   * Finds descendants for simple attribute-presence selectors. More complex
+   * selectors continue through Finder.
    * @private
    * @param {string} selector - The CSS selector to match against.
    * @param {Document|DocumentFragment|Element} node - The node to find within.
    * @returns {?Array<Element>} Matching elements, or `null` when this fast path does not apply.
    */
-  #findBySimpleDataAttribute = (selector, node) => {
+  #findBySimpleAttribute = (selector, node) => {
     if (typeof selector !== 'string') {
       return null;
     }
-    const match = REG_SIMPLE_DATA_ATTRIBUTE.exec(selector);
+    const match = REG_SIMPLE_ATTRIBUTE.exec(selector);
     if (
       !match ||
+      // Finder deliberately excludes xml:lang from unprefixed [lang].
+      match[1] === 'lang' ||
       (node.nodeType !== DOCUMENT_NODE &&
         node.nodeType !== DOCUMENT_FRAGMENT_NODE &&
         node.nodeType !== ELEMENT_NODE)
@@ -435,7 +445,7 @@ export class DOMSelector {
         node.nodeType === DOCUMENT_NODE ? node : node.ownerDocument;
       return collectAllDescendants(node, document);
     }
-    const fastNodes = this.#findBySimpleDataAttribute(selector, node);
+    const fastNodes = this.#findBySimpleAttribute(selector, node);
     if (fastNodes) {
       return fastNodes;
     }

--- a/src/index.js
+++ b/src/index.js
@@ -377,7 +377,7 @@ export class DOMSelector {
       return collectAllDescendants(node, document);
     }
     const fastNodes = findBySimpleAttribute(selector, node);
-    if (fastNodes !== null) {
+    if (Array.isArray(fastNodes)) {
       return fastNodes;
     }
     const nodes = this.#findNodes(selector, node, opt, TARGET_ALL);

--- a/src/js/utility.js
+++ b/src/js/utility.js
@@ -56,6 +56,7 @@ const REG_IS_HTML = /^text\/html$/;
 const REG_IS_XHTML = /^(?:application\/xhtml\+x|text\/ht)ml$/;
 const REG_IS_XML =
   /^(?:application\/(?:[\w\-.]+\+)?|image\/[\w\-.]+\+|text\/)xml$/;
+const REG_SIMPLE_ATTRIBUTE = /^\[([a-z][a-z0-9_-]*)\]$/;
 
 /**
  * Get type of an object.
@@ -923,6 +924,76 @@ export const collectAllDescendants = (node, document) => {
     refNode = walker.nextNode();
   }
   return descendants;
+};
+
+/**
+ * Tests whether an element has an attribute with the given local name.
+ * @param {Element} node - The element to test.
+ * @param {string} name - The lower-case attribute local name.
+ * @returns {boolean} `true` if the attribute is present.
+ */
+export const hasAttributeLocalName = (node, name) => {
+  if (node.hasAttribute(name)) {
+    return true;
+  }
+  const names = node.getAttributeNames();
+  for (let i = 0; i < names.length; i++) {
+    const itemName = names[i];
+    const colonIndex = itemName.indexOf(':');
+    if (colonIndex > -1) {
+      const localName = itemName.slice(colonIndex + 1);
+      if (
+        localName === name ||
+        (isHTMLElement(node) && localName.toLowerCase() === name)
+      ) {
+        return true;
+      }
+    }
+  }
+  return false;
+};
+
+/**
+ * Finds descendants for simple attribute-presence selectors.
+ * @param {string} selector - The CSS selector to match against.
+ * @param {Document|DocumentFragment|Element} node - The node to find within.
+ * @returns {?Array<Element>} Matching elements, or `null` when this function does not apply.
+ */
+export const findBySimpleAttribute = (selector, node) => {
+  if (typeof selector !== 'string') {
+    return null;
+  }
+  const match = REG_SIMPLE_ATTRIBUTE.exec(selector);
+  if (!match) {
+    return null;
+  }
+  const name = match[1];
+  // Finder deliberately excludes xml:lang from unprefixed [lang].
+  if (name === 'lang') {
+    return null;
+  }
+  const { nodeType } = node;
+  const isQueryContext =
+    nodeType === DOCUMENT_NODE ||
+    nodeType === DOCUMENT_FRAGMENT_NODE ||
+    nodeType === ELEMENT_NODE;
+  if (!isQueryContext) {
+    return null;
+  }
+  const document = nodeType === DOCUMENT_NODE ? node : node.ownerDocument;
+  if (document.contentType !== 'text/html') {
+    return null;
+  }
+  const walker = document.createTreeWalker(node, SHOW_ELEMENT);
+  const nodes = [];
+  let descendant = walker.nextNode();
+  while (descendant) {
+    if (hasAttributeLocalName(descendant, name)) {
+      nodes.push(descendant);
+    }
+    descendant = walker.nextNode();
+  }
+  return nodes;
 };
 
 /**

--- a/src/js/utility.js
+++ b/src/js/utility.js
@@ -937,8 +937,7 @@ export const hasAttributeLocalName = (node, name) => {
     return true;
   }
   const names = node.getAttributeNames();
-  for (let i = 0; i < names.length; i++) {
-    const itemName = names[i];
+  for (const itemName of names) {
     const colonIndex = itemName.indexOf(':');
     if (colonIndex > -1) {
       const localName = itemName.slice(colonIndex + 1);

--- a/src/js/utility.js
+++ b/src/js/utility.js
@@ -963,11 +963,14 @@ export const findBySimpleAttribute = (selector, node) => {
   if (typeof selector !== 'string') {
     return null;
   }
+  if (!node?.nodeType) {
+    return null;
+  }
   const match = REG_SIMPLE_ATTRIBUTE.exec(selector);
   if (!match) {
     return null;
   }
-  const name = match[1];
+  const [, name] = match;
   // Finder deliberately excludes xml:lang from unprefixed [lang].
   if (name === 'lang') {
     return null;
@@ -986,12 +989,12 @@ export const findBySimpleAttribute = (selector, node) => {
   }
   const walker = document.createTreeWalker(node, SHOW_ELEMENT);
   const nodes = [];
-  let descendant = walker.nextNode();
-  while (descendant) {
-    if (hasAttributeLocalName(descendant, name)) {
-      nodes.push(descendant);
+  let nextNode = walker.nextNode();
+  while (nextNode) {
+    if (hasAttributeLocalName(nextNode, name)) {
+      nodes.push(nextNode);
     }
-    descendant = walker.nextNode();
+    nextNode = walker.nextNode();
   }
   return nodes;
 };

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -12,8 +12,9 @@ import * as cssTree from 'css-tree';
 
 /* test */
 import { DOMSelector } from '../src/index.js';
+import { Finder } from '../src/js/finder.js';
 /* constants */
-import { SYNTAX_ERR } from '../src/js/constant.js';
+import { SYNTAX_ERR, TARGET_ALL } from '../src/js/constant.js';
 
 describe('DOMSelector', () => {
   const domStr = `<!doctype html>
@@ -2025,6 +2026,185 @@ describe('DOMSelector', () => {
         ],
         'result'
       );
+    });
+
+    it('should query simple data attribute selectors in tree order', () => {
+      const root = document.createElement('div');
+      const child1 = document.createElement('div');
+      const child2 = document.createElement('span');
+      root.setAttribute('data-testid', 'root');
+      child1.setAttribute('data-testid', 'first');
+      child2.setAttribute('data-testid', 'second');
+      child1.append(child2);
+      root.append(child1);
+      const domSelector = new DOMSelector(window);
+      const res = domSelector.querySelectorAll('[data-testid]', root);
+      assert.deepEqual(res, [child1, child2], 'result');
+    });
+
+    it('should query configured Testing Library data attributes', () => {
+      const root = document.createElement('div');
+      const child = document.createElement('span');
+      child.setAttribute('data-qa', 'target');
+      root.append(child);
+      const domSelector = new DOMSelector(window);
+      const res = domSelector.querySelectorAll('[data-qa]', root);
+      assert.deepEqual(res, [child], 'result');
+    });
+
+    it('should leave other attribute selector forms to Finder', () => {
+      const root = document.createElement('div');
+      root.innerHTML =
+        '<span class="target" data-testid="target" data-téstid="unicode" title="target"></span>' +
+        '<span class="other"></span>';
+      const selectors = [
+        '[ data-testid ]',
+        '[DATA-TESTID]',
+        '[data-testid="target"]',
+        '[data-testid^="tar"]',
+        'span[data-testid]',
+        '[data-testid], .other',
+        '[data\\-testid]',
+        '[data-testid="TARGET" i]',
+        '[title]',
+        '[data-téstid]',
+        '[*|data-testid]',
+        '[|data-testid]',
+        ':is([data-testid])'
+      ];
+      const domSelector = new DOMSelector(window);
+      for (const selector of selectors) {
+        const expected = [
+          ...new Finder(window).setup(selector, root).find(TARGET_ALL)
+        ];
+        const actual = domSelector.querySelectorAll(selector, root);
+        assert.deepEqual(actual, expected, selector);
+      }
+    });
+
+    it('should keep rejecting an invalid data attribute selector', () => {
+      const domSelector = new DOMSelector(window);
+      const selector = '[data-testid=]';
+      assert.throws(
+        () => domSelector.querySelectorAll(selector, document.body),
+        e => {
+          assert.strictEqual(e.name, SYNTAX_ERR, selector);
+          return true;
+        }
+      );
+    });
+
+    it('should keep rejecting unsupported query contexts', () => {
+      const domSelector = new DOMSelector(window);
+      assert.throws(
+        () =>
+          domSelector.querySelectorAll(
+            '[data-testid]',
+            document.createTextNode('text')
+          ),
+        window.TypeError,
+        'Unexpected node #text'
+      );
+    });
+
+    it('should include the document element for a document context', () => {
+      document.documentElement.setAttribute('data-testid', 'html');
+      const child = document.createElement('span');
+      child.setAttribute('data-testid', 'child');
+      document.body.append(child);
+      const domSelector = new DOMSelector(window);
+      const res = domSelector.querySelectorAll('[data-testid]', document);
+      assert.deepEqual(res, [document.documentElement, child], 'result');
+    });
+
+    it('should query simple data attributes in fragments and shadow roots', () => {
+      const fragment = document.createDocumentFragment();
+      const fragmentChild = document.createElement('span');
+      fragmentChild.setAttribute('data-testid', 'fragment');
+      fragment.append(fragmentChild);
+      const host = document.createElement('div');
+      const shadow = host.attachShadow({ mode: 'open' });
+      const shadowChild = document.createElement('span');
+      shadowChild.setAttribute('data-testid', 'shadow');
+      shadow.append(shadowChild);
+      const lightChild = document.createElement('span');
+      lightChild.setAttribute('data-testid', 'light');
+      host.append(lightChild);
+      const domSelector = new DOMSelector(window);
+      assert.deepEqual(
+        domSelector.querySelectorAll('[data-testid]', fragment),
+        [fragmentChild],
+        'fragment'
+      );
+      assert.deepEqual(
+        domSelector.querySelectorAll('[data-testid]', shadow),
+        [shadowChild],
+        'shadow root'
+      );
+      assert.deepEqual(
+        domSelector.querySelectorAll('[data-testid]', host),
+        [lightChild],
+        'light tree does not cross the shadow boundary'
+      );
+    });
+
+    it('should preserve local-name matching for namespaced attributes', () => {
+      const root = document.createElement('div');
+      const matchingSvg = document.createElementNS(
+        'http://www.w3.org/2000/svg',
+        'svg'
+      );
+      const caseSensitiveSvg = document.createElementNS(
+        'http://www.w3.org/2000/svg',
+        'svg'
+      );
+      matchingSvg.setAttributeNS('urn:test', 'x:data-testid', 'target');
+      caseSensitiveSvg.setAttributeNS('urn:test', 'x:data-TestID', 'target');
+      root.append(matchingSvg, caseSensitiveSvg);
+      const domSelector = new DOMSelector(window);
+      const res = domSelector.querySelectorAll('[data-testid]', root);
+      assert.deepEqual(res, [matchingSvg], 'result');
+    });
+
+    it('should leave simple data attribute queries on XML documents to Finder', () => {
+      const xmlDom = new JSDOM('<root><child data-testid="target"/></root>', {
+        contentType: 'application/xml'
+      });
+      const xmlDocument = xmlDom.window.document;
+      const domSelector = new DOMSelector(xmlDom.window);
+      const res = domSelector.querySelectorAll(
+        '[data-testid]',
+        xmlDocument.documentElement
+      );
+      assert.deepEqual(res, [xmlDocument.documentElement.firstElementChild]);
+      xmlDom.window.close();
+    });
+
+    it('should return a static data attribute query result after mutations', () => {
+      const root = document.createElement('div');
+      const child1 = document.createElement('span');
+      const child2 = document.createElement('span');
+      child1.setAttribute('data-testid', 'first');
+      root.append(child1, child2);
+      const domSelector = new DOMSelector(window);
+      const before = domSelector.querySelectorAll('[data-testid]', root);
+      child1.removeAttribute('data-testid');
+      child2.setAttribute('data-testid', 'second');
+      const after = domSelector.querySelectorAll('[data-testid]', root);
+      assert.notStrictEqual(after, before, 'fresh result');
+      assert.deepEqual(before, [child1], 'before mutation');
+      assert.deepEqual(after, [child2], 'after mutation');
+    });
+
+    it('should use the simple data attribute path with jsdom impl nodes', () => {
+      const child = document.createElement('span');
+      child.setAttribute('data-testid', 'target');
+      document.body.append(child);
+      const documentImpl = idlUtils.implForWrapper(document);
+      const bodyImpl = idlUtils.implForWrapper(document.body);
+      const domSelector = new DOMSelector(window, documentImpl, { idlUtils });
+      const res = domSelector.querySelectorAll('[data-testid]', bodyImpl);
+      assert.deepEqual(res, [child], 'result');
     });
   });
 });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -12,9 +12,8 @@ import * as cssTree from 'css-tree';
 
 /* test */
 import { DOMSelector } from '../src/index.js';
-import { Finder } from '../src/js/finder.js';
 /* constants */
-import { SYNTAX_ERR, TARGET_ALL } from '../src/js/constant.js';
+import { SYNTAX_ERR } from '../src/js/constant.js';
 
 describe('DOMSelector', () => {
   const domStr = `<!doctype html>
@@ -2030,68 +2029,33 @@ describe('DOMSelector', () => {
 
     it('should query simple data attribute selectors in tree order', () => {
       const root = document.createElement('div');
-      const child1 = document.createElement('div');
-      const child2 = document.createElement('span');
-      root.setAttribute('data-testid', 'root');
-      child1.setAttribute('data-testid', 'first');
-      child2.setAttribute('data-testid', 'second');
-      child1.append(child2);
-      root.append(child1);
-      const domSelector = new DOMSelector(window);
-      const res = domSelector.querySelectorAll('[data-testid]', root);
-      assert.deepEqual(res, [child1, child2], 'result');
-    });
-
-    it('should query configured Testing Library data attributes', () => {
-      const root = document.createElement('div');
-      const child = document.createElement('span');
-      child.setAttribute('data-qa', 'target');
-      root.append(child);
+      root.setAttribute('data-qa', 'root');
+      root.innerHTML =
+        '<div data-qa="first"><span data-qa="second"></span></div>';
+      const child1 = root.firstElementChild;
+      const child2 = child1.firstElementChild;
       const domSelector = new DOMSelector(window);
       const res = domSelector.querySelectorAll('[data-qa]', root);
-      assert.deepEqual(res, [child], 'result');
+      assert.deepEqual(res, [child1, child2], 'result');
     });
 
     it('should leave other attribute selector forms to Finder', () => {
       const root = document.createElement('div');
       root.innerHTML =
-        '<span class="target" data-testid="target" data-téstid="unicode" title="target"></span>' +
+        '<span class="target" data-testid="target"></span>' +
         '<span class="other"></span>';
-      const selectors = [
-        '[ data-testid ]',
-        '[DATA-TESTID]',
-        '[data-testid="target"]',
-        '[data-testid^="tar"]',
-        'span[data-testid]',
-        '[data-testid], .other',
-        '[data\\-testid]',
-        '[data-testid="TARGET" i]',
-        '[title]',
-        '[data-téstid]',
-        '[*|data-testid]',
-        '[|data-testid]',
-        ':is([data-testid])'
+      const [target, other] = root.children;
+      const cases = [
+        ['[DATA-TESTID]', [target]],
+        ['[data-testid="target"]', [target]],
+        ['span[data-testid]', [target]],
+        ['[data-testid], .other', [target, other]]
       ];
       const domSelector = new DOMSelector(window);
-      for (const selector of selectors) {
-        const expected = [
-          ...new Finder(window).setup(selector, root).find(TARGET_ALL)
-        ];
+      for (const [selector, expected] of cases) {
         const actual = domSelector.querySelectorAll(selector, root);
         assert.deepEqual(actual, expected, selector);
       }
-    });
-
-    it('should keep rejecting an invalid data attribute selector', () => {
-      const domSelector = new DOMSelector(window);
-      const selector = '[data-testid=]';
-      assert.throws(
-        () => domSelector.querySelectorAll(selector, document.body),
-        e => {
-          assert.strictEqual(e.name, SYNTAX_ERR, selector);
-          return true;
-        }
-      );
     });
 
     it('should keep rejecting unsupported query contexts', () => {
@@ -2107,60 +2071,34 @@ describe('DOMSelector', () => {
       );
     });
 
-    it('should include the document element for a document context', () => {
+    it('should query document and shadow root contexts', () => {
       document.documentElement.setAttribute('data-testid', 'html');
       const child = document.createElement('span');
       child.setAttribute('data-testid', 'child');
       document.body.append(child);
-      const domSelector = new DOMSelector(window);
-      const res = domSelector.querySelectorAll('[data-testid]', document);
-      assert.deepEqual(res, [document.documentElement, child], 'result');
-    });
-
-    it('should query simple data attributes in fragments and shadow roots', () => {
-      const fragment = document.createDocumentFragment();
-      const fragmentChild = document.createElement('span');
-      fragmentChild.setAttribute('data-testid', 'fragment');
-      fragment.append(fragmentChild);
       const host = document.createElement('div');
       const shadow = host.attachShadow({ mode: 'open' });
-      const shadowChild = document.createElement('span');
-      shadowChild.setAttribute('data-testid', 'shadow');
-      shadow.append(shadowChild);
-      const lightChild = document.createElement('span');
-      lightChild.setAttribute('data-testid', 'light');
-      host.append(lightChild);
+      shadow.innerHTML = '<span data-testid="shadow"></span>';
+      const shadowChild = shadow.firstElementChild;
       const domSelector = new DOMSelector(window);
       assert.deepEqual(
-        domSelector.querySelectorAll('[data-testid]', fragment),
-        [fragmentChild],
-        'fragment'
+        domSelector.querySelectorAll('[data-testid]', document),
+        [document.documentElement, child],
+        'document'
       );
       assert.deepEqual(
         domSelector.querySelectorAll('[data-testid]', shadow),
         [shadowChild],
         'shadow root'
       );
-      assert.deepEqual(
-        domSelector.querySelectorAll('[data-testid]', host),
-        [lightChild],
-        'light tree does not cross the shadow boundary'
-      );
     });
 
     it('should preserve local-name matching for namespaced attributes', () => {
       const root = document.createElement('div');
-      const matchingSvg = document.createElementNS(
-        'http://www.w3.org/2000/svg',
-        'svg'
-      );
-      const caseSensitiveSvg = document.createElementNS(
-        'http://www.w3.org/2000/svg',
-        'svg'
-      );
+      root.innerHTML = '<svg></svg><svg></svg>';
+      const [matchingSvg, caseSensitiveSvg] = root.children;
       matchingSvg.setAttributeNS('urn:test', 'x:data-testid', 'target');
       caseSensitiveSvg.setAttributeNS('urn:test', 'x:data-TestID', 'target');
-      root.append(matchingSvg, caseSensitiveSvg);
       const domSelector = new DOMSelector(window);
       const res = domSelector.querySelectorAll('[data-testid]', root);
       assert.deepEqual(res, [matchingSvg], 'result');
@@ -2182,10 +2120,8 @@ describe('DOMSelector', () => {
 
     it('should return a static data attribute query result after mutations', () => {
       const root = document.createElement('div');
-      const child1 = document.createElement('span');
-      const child2 = document.createElement('span');
-      child1.setAttribute('data-testid', 'first');
-      root.append(child1, child2);
+      root.innerHTML = '<span data-testid="first"></span><span></span>';
+      const [child1, child2] = root.children;
       const domSelector = new DOMSelector(window);
       const before = domSelector.querySelectorAll('[data-testid]', root);
       child1.removeAttribute('data-testid');

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -2027,29 +2027,34 @@ describe('DOMSelector', () => {
       );
     });
 
-    it('should query simple data attribute selectors in tree order', () => {
+    it('should query simple attribute selectors in tree order', () => {
       const root = document.createElement('div');
-      root.setAttribute('data-qa', 'root');
-      root.innerHTML =
-        '<div data-qa="first"><span data-qa="second"></span></div>';
+      root.setAttribute('hidden', '');
+      root.innerHTML = '<div hidden><span hidden></span></div>';
       const child1 = root.firstElementChild;
       const child2 = child1.firstElementChild;
       const domSelector = new DOMSelector(window);
-      const res = domSelector.querySelectorAll('[data-qa]', root);
+      const res = domSelector.querySelectorAll('[hidden]', root);
       assert.deepEqual(res, [child1, child2], 'result');
     });
 
-    it('should leave other attribute selector forms to Finder', () => {
+    it('should leave unsupported attribute selectors to Finder', () => {
       const root = document.createElement('div');
       root.innerHTML =
         '<span class="target" data-testid="target"></span>' +
         '<span class="other"></span>';
       const [target, other] = root.children;
+      target.setAttributeNS(
+        'http://www.w3.org/XML/1998/namespace',
+        'xml:lang',
+        'en'
+      );
       const cases = [
         ['[DATA-TESTID]', [target]],
         ['[data-testid="target"]', [target]],
         ['span[data-testid]', [target]],
-        ['[data-testid], .other', [target, other]]
+        ['[data-testid], .other', [target, other]],
+        ['[lang]', []]
       ];
       const domSelector = new DOMSelector(window);
       for (const [selector, expected] of cases) {
@@ -2095,16 +2100,17 @@ describe('DOMSelector', () => {
 
     it('should preserve local-name matching for namespaced attributes', () => {
       const root = document.createElement('div');
-      root.innerHTML = '<svg></svg><svg></svg>';
-      const [matchingSvg, caseSensitiveSvg] = root.children;
+      root.innerHTML = '<span></span><svg></svg><svg></svg>';
+      const [htmlElement, matchingSvg, caseSensitiveSvg] = root.children;
+      htmlElement.setAttributeNS('urn:test', 'x:data-TestID', 'target');
       matchingSvg.setAttributeNS('urn:test', 'x:data-testid', 'target');
       caseSensitiveSvg.setAttributeNS('urn:test', 'x:data-TestID', 'target');
       const domSelector = new DOMSelector(window);
       const res = domSelector.querySelectorAll('[data-testid]', root);
-      assert.deepEqual(res, [matchingSvg], 'result');
+      assert.deepEqual(res, [htmlElement, matchingSvg], 'result');
     });
 
-    it('should leave simple data attribute queries on XML documents to Finder', () => {
+    it('should leave simple attribute queries on XML documents to Finder', () => {
       const xmlDom = new JSDOM('<root><child data-testid="target"/></root>', {
         contentType: 'application/xml'
       });

--- a/test/utility.test.js
+++ b/test/utility.test.js
@@ -2546,6 +2546,52 @@ describe('utility functions', () => {
   describe('findBySimpleAttribute', () => {
     const func = util.findBySimpleAttribute;
 
+    it('should return null if selector is not a string', () => {
+      const root = document.createElement('div');
+      const invalidSelectors = [undefined, null, 123, true, {}, []];
+      for (const selector of invalidSelectors) {
+        assert.strictEqual(
+          func(selector, root),
+          null,
+          `Testing with: ${String(selector)}`
+        );
+      }
+    });
+
+    it('should return null if node is not a valid query context', () => {
+      const textNode = document.createTextNode('text');
+      const commentNode = document.createComment('comment');
+      const attrNode = document.createAttribute('data-test');
+      assert.strictEqual(func('[hidden]', {}), null, 'Plain object');
+      assert.strictEqual(func('[hidden]', textNode), null, 'Text node');
+      assert.strictEqual(func('[hidden]', commentNode), null, 'Comment node');
+      assert.strictEqual(func('[hidden]', attrNode), null, 'Attribute node');
+    });
+
+    it('should return null if document contentType is not text/html', () => {
+      // text/xml
+      const xmlStr = '<root><child hidden=""></child></root>';
+      const xmlDoc = new window.DOMParser().parseFromString(xmlStr, 'text/xml');
+      // application/xhtml+xml
+      const xhtmlStr =
+        '<html xmlns="http://www.w3.org/1999/xhtml"><body hidden=""></body></html>';
+      const xhtmlDoc = new window.DOMParser().parseFromString(
+        xhtmlStr,
+        'application/xhtml+xml'
+      );
+      assert.strictEqual(func('[hidden]', xmlDoc), null, 'XML Document node');
+      assert.strictEqual(
+        func('[hidden]', xmlDoc.documentElement),
+        null,
+        'XML Element node'
+      );
+      assert.strictEqual(
+        func('[hidden]', xhtmlDoc),
+        null,
+        'XHTML Document node'
+      );
+    });
+
     it('should find matching descendants in tree order', () => {
       const root = document.createElement('div');
       root.setAttribute('hidden', '');

--- a/test/utility.test.js
+++ b/test/utility.test.js
@@ -2522,6 +2522,49 @@ describe('utility functions', () => {
     });
   });
 
+  describe('hasAttributeLocalName', () => {
+    const func = util.hasAttributeLocalName;
+
+    it('should match attributes by local name', () => {
+      const node = document.createElement('div');
+      const htmlNode = document.createElement('div');
+      const svgNode = document.createElementNS(
+        'http://www.w3.org/2000/svg',
+        'svg'
+      );
+      node.setAttribute('data-testid', 'target');
+      htmlNode.setAttributeNS('urn:test', 'x:data-TestID', 'target');
+      svgNode.setAttributeNS('urn:test', 'x:data-TestID', 'target');
+      assert.strictEqual(func(node, 'data-testid'), true, 'matching');
+      assert.strictEqual(func(node, 'hidden'), false, 'not matching');
+      assert.strictEqual(func(htmlNode, 'data-testid'), true, 'HTML element');
+      assert.strictEqual(func(svgNode, 'data-testid'), false, 'SVG element');
+      assert.strictEqual(func(svgNode, 'data-TestID'), true, 'case-sensitive');
+    });
+  });
+
+  describe('findBySimpleAttribute', () => {
+    const func = util.findBySimpleAttribute;
+
+    it('should find matching descendants in tree order', () => {
+      const root = document.createElement('div');
+      root.setAttribute('hidden', '');
+      root.innerHTML =
+        '<div hidden><span></span></div><p><span hidden></span></p>';
+      const first = root.firstElementChild;
+      const second = root.lastElementChild.firstElementChild;
+      assert.deepEqual(func('[hidden]', root), [first, second], 'result');
+    });
+
+    it('should return null for selectors handled by Finder', () => {
+      const root = document.createElement('div');
+      const selectors = ['[data-testid="target"]', '[lang]'];
+      for (const selector of selectors) {
+        assert.strictEqual(func(selector, root), null, String(selector));
+      }
+    });
+  });
+
   describe('get traversal strategy', () => {
     const func = util.getTraversalStrategy;
 

--- a/types/js/utility.d.ts
+++ b/types/js/utility.d.ts
@@ -23,4 +23,6 @@ export declare const sortNodes: (nodes?: Array<object> | Set<object>) => Array<o
 export declare const findBestSeed: (nodes: any[], state?: object) => object;
 export declare const populateHasAllowlist: (current: object, list: WeakSet<any>, visitedAncestors: Set<any>) => void;
 export declare const collectAllDescendants: (node: Document | DocumentFragment | Element, document: Document) => Array<Element>;
+export declare const hasAttributeLocalName: (node: Element, name: string) => boolean;
+export declare const findBySimpleAttribute: (selector: string, node: Document | DocumentFragment | Element) => Array<Element> | null;
 export declare const getTraversalStrategy: (branch: Array<object>, targetType: string, hasScope: boolean, scoped: boolean) => object;


### PR DESCRIPTION
Exact lowercase attribute presence queries currently pay for full Finder setup even though matching only needs an attribute check. This shows up in jsdom tests through Testing Library, which scans `[data-testid]` before filtering values.

Route simple selectors such as `[data-testid]`, `[title]`, `[hidden]`, and `[aria-label]` through a stateless TreeWalker scan. More complex selectors and XML documents stay on Finder. `[lang]` also stays on Finder because of its existing `xml:lang` behavior. The shortcut preserves existing namespace and context behavior, returns a fresh static result, and does not add another selector result cache.

| Rendered DOM | Before per query | After per query | Saved per query |
|---|---:|---:|---:|
| 70 elements, 2 test IDs | 0.116 ms | 0.035 ms | 0.081 ms / 3.35x |
| 280 elements, 8 test IDs | 0.416 ms | 0.112 ms | 0.305 ms / 3.73x |
| 7,000 elements, 101 test IDs | 12.72 ms | 3.00 ms | 9.72 ms / 4.25x |

These use the real jsdom Web IDL and Testing Library `queryAllByTestId()` path, an unrelated attribute mutation before each query, and nine alternating isolated baseline/candidate pairs. The 70 and 280 element cases represent a small component and a rendered list rather than only a stress test.

A separate direct `querySelectorAll()` stress comparison over 7,000 elements was 6.81-7.19x faster across `[data-testid]`, `[title]`, `[hidden]`, and `[aria-label]`.