### PR TITLE
Use getElementById() for exact ID attribute queries

### DIFF
--- a/benchmark/bench-testing-library.js
+++ b/benchmark/bench-testing-library.js
@@ -60,6 +60,17 @@ const targetRole = document.createElement('div');
 targetRole.setAttribute('data-role', 'component tile active'); // スペース区切りの複数値
 root.appendChild(targetRole);
 
+const labelElements = [...root.querySelectorAll('div[data-testid]')].slice(
+  0,
+  24
+);
+const labelledControls = [...root.querySelectorAll('input')].slice(0, 24);
+for (let i = 0; i < labelledControls.length; i++) {
+  const id = `base-ui-«r${i}»-label`;
+  labelElements[i].id = id;
+  labelledControls[i].setAttribute('aria-labelledby', id);
+}
+
 const totalElements = document.querySelectorAll('*').length;
 
 const domSelector = new DOMSelector(window);
@@ -71,6 +82,13 @@ const rootImpl = idlUtils.implForWrapper(root);
 const implicitRoleCandidates = [...document.querySelectorAll('input')].map(
   idlUtils.implForWrapper
 );
+
+function resolveLabels(selectorEngine, context) {
+  for (const control of labelledControls) {
+    const id = control.getAttribute('aria-labelledby');
+    selectorEngine.querySelector(`[id="${id}"]`, context);
+  }
+}
 
 console.log(`=======================================`);
 console.log(`DOMSelector Testing Library Queries Benchmark`);
@@ -106,6 +124,10 @@ group(`Testing Library Typical Queries (document)`, () => {
   bench(`[title="target-title"], svg title`, () => {
     domSelector.querySelectorAll('[title="target-title"], svg title', document);
   });
+
+  bench(`24 aria-labelledby ID references`, () => {
+    resolveLabels(domSelector, document);
+  });
 });
 
 group(`Testing Library Typical Queries (Element)`, () => {
@@ -136,6 +158,10 @@ group(`Testing Library Typical Queries (Element)`, () => {
   bench(`[title="target-title"], svg title`, () => {
     domSelector.querySelectorAll('[title="target-title"], svg title', root);
   });
+
+  bench(`24 aria-labelledby ID references`, () => {
+    resolveLabels(domSelector, root);
+  });
 });
 
 group(`Testing Library Implicit Role Matching (jsdom)`, () => {
@@ -151,6 +177,10 @@ group(`Testing Library Implicit Role Matching (jsdom)`, () => {
     for (const candidate of implicitRoleCandidates) {
       jsdomSelector.matches('input:not([type]):not([list])', candidate);
     }
+  });
+
+  bench(`24 aria-labelledby ID references`, () => {
+    resolveLabels(jsdomSelector, rootImpl);
   });
 });
 

--- a/src/index.js
+++ b/src/index.js
@@ -17,6 +17,7 @@ import {
 } from './js/selector.js';
 import {
   collectAllDescendants,
+  findByExactIdAttribute,
   findBySimpleAttribute,
   getType
 } from './js/utility.js';
@@ -278,6 +279,10 @@ export class DOMSelector {
     }
     if (REG_UNIVERSAL.test(selector)) {
       return node.firstElementChild;
+    }
+    const fastNode = findByExactIdAttribute(selector, node);
+    if (fastNode !== undefined) {
+      return fastNode;
     }
     const nodes = this.#findNodes(selector, node, opt, TARGET_FIRST);
     if (nodes && nodes.size) {

--- a/src/index.js
+++ b/src/index.js
@@ -281,7 +281,7 @@ export class DOMSelector {
       return node.firstElementChild;
     }
     const fastNode = findByExactIdAttribute(selector, node);
-    if (fastNode !== undefined) {
+    if (fastNode === null || fastNode?.nodeType === ELEMENT_NODE) {
       return fastNode;
     }
     const nodes = this.#findNodes(selector, node, opt, TARGET_FIRST);

--- a/src/js/utility.js
+++ b/src/js/utility.js
@@ -56,7 +56,8 @@ const REG_IS_HTML = /^text\/html$/;
 const REG_IS_XHTML = /^(?:application\/xhtml\+x|text\/ht)ml$/;
 const REG_IS_XML =
   /^(?:application\/(?:[\w\-.]+\+)?|image\/[\w\-.]+\+|text\/)xml$/;
-const REG_EXACT_ID_ATTRIBUTE = /^\[id="([\x21\x23-\x5b\x5d-\x7e«»]+)"\]$/;
+const REG_EXACT_ID_ATTRIBUTE =
+  /^\[id="([A-Za-z]\w*(?:-(?:\w*|\u00AB\w+\u00BB))*)"\]$/;
 const REG_SIMPLE_ATTRIBUTE = /^\[([a-z][a-z0-9_-]*)\]$/;
 
 /**
@@ -963,9 +964,6 @@ export const hasAttributeLocalName = (node, name) => {
  */
 export const findByExactIdAttribute = (selector, node) => {
   if (typeof selector !== 'string') {
-    return;
-  }
-  if (!selector.startsWith('[id="')) {
     return;
   }
   if (!node?.nodeType) {

--- a/src/js/utility.js
+++ b/src/js/utility.js
@@ -56,6 +56,7 @@ const REG_IS_HTML = /^text\/html$/;
 const REG_IS_XHTML = /^(?:application\/xhtml\+x|text\/ht)ml$/;
 const REG_IS_XML =
   /^(?:application\/(?:[\w\-.]+\+)?|image\/[\w\-.]+\+|text\/)xml$/;
+const REG_EXACT_ID_ATTRIBUTE = /^\[id="([^"\\]+)"\]$/u;
 const REG_SIMPLE_ATTRIBUTE = /^\[([a-z][a-z0-9_-]*)\]$/;
 
 /**
@@ -951,6 +952,56 @@ export const hasAttributeLocalName = (node, name) => {
     }
   }
   return false;
+};
+
+/**
+ * Finds the first descendant for an exact ID attribute selector.
+ * @param {string} selector - The CSS selector to match against.
+ * @param {Document|DocumentFragment|Element} node - The node to find within.
+ * @returns {Element|null|undefined} The matching element, `null` if no ID exists,
+ * or `undefined` when the normal selector engine must be used.
+ */
+export const findByExactIdAttribute = (selector, node) => {
+  if (typeof selector !== 'string') {
+    return undefined;
+  }
+  if (!selector.startsWith('[id="')) {
+    return undefined;
+  }
+  if (!node?.nodeType) {
+    return undefined;
+  }
+  const match = REG_EXACT_ID_ATTRIBUTE.exec(selector);
+  if (!match) {
+    return undefined;
+  }
+  const [, id] = match;
+  if (!id.isWellFormed()) {
+    return undefined;
+  }
+  for (let i = 0; i < id.length; i++) {
+    const codeUnit = id.charCodeAt(i);
+    if (codeUnit <= 0x1f || codeUnit === 0x7f) {
+      return undefined;
+    }
+  }
+  if (node.nodeType === DOCUMENT_NODE) {
+    return node.getElementById(id);
+  }
+  if (
+    node.nodeType !== ELEMENT_NODE ||
+    node.getRootNode() !== node.ownerDocument
+  ) {
+    return undefined;
+  }
+  const candidate = node.ownerDocument.getElementById(id);
+  if (candidate === null) {
+    return null;
+  }
+  if (candidate !== node && node.contains(candidate)) {
+    return candidate;
+  }
+  return undefined;
 };
 
 /**

--- a/src/js/utility.js
+++ b/src/js/utility.js
@@ -56,10 +56,7 @@ const REG_IS_HTML = /^text\/html$/;
 const REG_IS_XHTML = /^(?:application\/xhtml\+x|text\/ht)ml$/;
 const REG_IS_XML =
   /^(?:application\/(?:[\w\-.]+\+)?|image\/[\w\-.]+\+|text\/)xml$/;
-// Space and printable ASCII except double quotes and backslashes,
-// plus non-ASCII Unicode scalar values.
-const REG_EXACT_ID_ATTRIBUTE =
-  /^\[id="([\x20\x21\x23-\x5b\x5d-\x7e\u0080-\ud7ff\ue000-\u{10ffff}]+)"\]$/u;
+const REG_EXACT_ID_ATTRIBUTE = /^\[id="([\x21\x23-\x5b\x5d-\x7e«»]+)"\]$/;
 const REG_SIMPLE_ATTRIBUTE = /^\[([a-z][a-z0-9_-]*)\]$/;
 
 /**

--- a/src/js/utility.js
+++ b/src/js/utility.js
@@ -56,7 +56,10 @@ const REG_IS_HTML = /^text\/html$/;
 const REG_IS_XHTML = /^(?:application\/xhtml\+x|text\/ht)ml$/;
 const REG_IS_XML =
   /^(?:application\/(?:[\w\-.]+\+)?|image\/[\w\-.]+\+|text\/)xml$/;
-const REG_EXACT_ID_ATTRIBUTE = /^\[id="([^"\\]+)"\]$/u;
+// Space and printable ASCII except double quotes and backslashes,
+// plus non-ASCII Unicode scalar values.
+const REG_EXACT_ID_ATTRIBUTE =
+  /^\[id="([\x20\x21\x23-\x5b\x5d-\x7e\u0080-\ud7ff\ue000-\u{10ffff}]+)"\]$/u;
 const REG_SIMPLE_ATTRIBUTE = /^\[([a-z][a-z0-9_-]*)\]$/;
 
 /**
@@ -963,28 +966,19 @@ export const hasAttributeLocalName = (node, name) => {
  */
 export const findByExactIdAttribute = (selector, node) => {
   if (typeof selector !== 'string') {
-    return undefined;
+    return;
   }
   if (!selector.startsWith('[id="')) {
-    return undefined;
+    return;
   }
   if (!node?.nodeType) {
-    return undefined;
+    return;
   }
   const match = REG_EXACT_ID_ATTRIBUTE.exec(selector);
   if (!match) {
-    return undefined;
+    return;
   }
   const [, id] = match;
-  if (!id.isWellFormed()) {
-    return undefined;
-  }
-  for (let i = 0; i < id.length; i++) {
-    const codeUnit = id.charCodeAt(i);
-    if (codeUnit <= 0x1f || codeUnit === 0x7f) {
-      return undefined;
-    }
-  }
   if (node.nodeType === DOCUMENT_NODE) {
     return node.getElementById(id);
   }
@@ -992,7 +986,7 @@ export const findByExactIdAttribute = (selector, node) => {
     node.nodeType !== ELEMENT_NODE ||
     node.getRootNode() !== node.ownerDocument
   ) {
-    return undefined;
+    return;
   }
   const candidate = node.ownerDocument.getElementById(id);
   if (candidate === null) {
@@ -1001,7 +995,6 @@ export const findByExactIdAttribute = (selector, node) => {
   if (candidate !== node && node.contains(candidate)) {
     return candidate;
   }
-  return undefined;
 };
 
 /**

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1345,12 +1345,133 @@ describe('DOMSelector', () => {
       assert.deepEqual(res, target, 'result');
     });
 
-    it('should query single element matching attribute selector', () => {
-      const node = document.getElementById('div1');
+    it('should query exact ID attributes in document and element contexts', () => {
+      const root = document.getElementById('div1');
       const target = document.getElementById('dt1');
+      target.id = 'base-ui-«r1»-label';
       const domSelector = new DOMSelector(window);
-      const res = domSelector.querySelector('[id="dt1"]', node);
-      assert.deepEqual(res, target, 'result');
+      const selector = '[id="base-ui-«r1»-label"]';
+      assert.strictEqual(domSelector.querySelector(selector, document), target);
+      assert.strictEqual(domSelector.querySelector(selector, root), target);
+
+      target.id = 'updated';
+      assert.strictEqual(domSelector.querySelector(selector, document), null);
+      assert.strictEqual(
+        domSelector.querySelector('[id="updated"]', document),
+        target
+      );
+    });
+
+    it('should handle duplicate IDs in element contexts', () => {
+      const outside = document.createElement('div');
+      outside.id = 'duplicate';
+      const root = document.createElement('div');
+      const inside = root.appendChild(document.createElement('span'));
+      inside.id = 'duplicate';
+      document.body.append(outside, root);
+      const domSelector = new DOMSelector(window);
+      assert.strictEqual(
+        domSelector.querySelector('[id="duplicate"]', root),
+        inside,
+        'first document match is outside the context'
+      );
+
+      root.id = 'context';
+      const child = root.appendChild(document.createElement('span'));
+      child.id = 'context';
+      assert.strictEqual(
+        domSelector.querySelector('[id="context"]', root),
+        child,
+        'context cannot select itself'
+      );
+    });
+
+    it('should query exact ID attributes outside the document tree', () => {
+      const detached = document.createElement('div');
+      const detachedTarget = detached.appendChild(
+        document.createElement('span')
+      );
+      detachedTarget.id = 'detached';
+      const domSelector = new DOMSelector(window);
+      assert.strictEqual(
+        domSelector.querySelector('[id="detached"]', detached),
+        detachedTarget,
+        'result'
+      );
+    });
+
+    it('should defer exact ID selectors that require CSS parsing', () => {
+      const target = document.body.appendChild(document.createElement('div'));
+      const domSelector = new DOMSelector(window);
+
+      const cases = [
+        ['', '[id=""]'],
+        ['quote"value', '[id="quote\\"value"]']
+      ];
+      for (const [id, selector] of cases) {
+        target.id = id;
+        assert.strictEqual(
+          domSelector.querySelector(selector, document),
+          target
+        );
+      }
+    });
+
+    it('should only match exact ID attributes in the null namespace', () => {
+      const namespaced = document.createElement('div');
+      namespaced.setAttributeNS('urn:test', 'x:id', 'target');
+      const nonLowercase = document.createElement('div');
+      nonLowercase.setAttributeNS(null, 'ID', 'non-lowercase');
+      document.body.append(namespaced, nonLowercase);
+      const domSelector = new DOMSelector(window);
+      assert.strictEqual(
+        domSelector.querySelector('[id="target"]', document),
+        null,
+        'namespaced attribute'
+      );
+      assert.strictEqual(
+        domSelector.querySelector('[id="non-lowercase"]', document),
+        null,
+        'non-lowercase attribute'
+      );
+
+      const target = document.body.appendChild(
+        document.createElementNS('http://www.w3.org/2000/svg', 'svg')
+      );
+      target.id = 'target';
+      assert.strictEqual(
+        domSelector.querySelector('[id="target"]', document),
+        target,
+        'null-namespace attribute'
+      );
+
+      const xmlDocument = new window.DOMParser().parseFromString(
+        '<root><target id="case-sensitive"/></root>',
+        'text/xml'
+      );
+      assert.strictEqual(
+        domSelector.querySelector('[id="case-sensitive"]', xmlDocument),
+        xmlDocument.documentElement.firstElementChild,
+        'XML document'
+      );
+    });
+
+    it('should query exact ID attributes after adoption', () => {
+      const target = document.body.appendChild(document.createElement('div'));
+      target.id = 'adopted';
+      const domSelector = new DOMSelector(window);
+      const otherDocument = document.implementation.createHTMLDocument();
+      otherDocument.body.appendChild(target);
+      assert.strictEqual(
+        domSelector.querySelector('[id="adopted"]', document),
+        null,
+        'old document'
+      );
+      assert.strictEqual(
+        domSelector.querySelector('[id="adopted"]', otherDocument),
+        target,
+        'new document'
+      );
     });
 
     // FIXME

--- a/test/utility.test.js
+++ b/test/utility.test.js
@@ -2571,11 +2571,14 @@ describe('utility functions', () => {
     it('should find an exact ID in document and element contexts', () => {
       const root = document.createElement('div');
       const target = root.appendChild(document.createElement('span'));
-      target.id = 'base-ui-«r1»-label';
       document.body.appendChild(root);
-      const selector = '[id="base-ui-«r1»-label"]';
-      assert.strictEqual(func(selector, document), target, 'Document');
-      assert.strictEqual(func(selector, root), target, 'Element');
+      const ids = ['base-ui-«r1»-label', 'punctuation-[]=', 'emoji-😀'];
+      for (const id of ids) {
+        target.id = id;
+        const selector = `[id="${id}"]`;
+        assert.strictEqual(func(selector, document), target, `Document: ${id}`);
+        assert.strictEqual(func(selector, root), target, `Element: ${id}`);
+      }
     });
 
     it('should return null when the document has no matching ID', () => {
@@ -2618,6 +2621,8 @@ describe('utility functions', () => {
         ['single-quoted value', "[id='target']", document],
         ['uppercase name', '[ID="target"]', document],
         ['control character', `[id="${String.fromCharCode(0)}"]`, document],
+        ['newline', '[id="\n"]', document],
+        ['delete character', `[id="${String.fromCharCode(0x7f)}"]`, document],
         ['lone surrogate', `[id="${String.fromCharCode(0xd800)}"]`, document],
         ['detached Element', '[id="target"]', detached],
         ['DocumentFragment', '[id="target"]', fragment],

--- a/test/utility.test.js
+++ b/test/utility.test.js
@@ -2572,7 +2572,7 @@ describe('utility functions', () => {
       const root = document.createElement('div');
       const target = root.appendChild(document.createElement('span'));
       document.body.appendChild(root);
-      const ids = ['base-ui-«r1»-label', 'punctuation-[]=', 'emoji-😀'];
+      const ids = ['base-ui-«r1»-label', 'punctuation-[]='];
       for (const id of ids) {
         target.id = id;
         const selector = `[id="${id}"]`;
@@ -2623,6 +2623,8 @@ describe('utility functions', () => {
         ['control character', `[id="${String.fromCharCode(0)}"]`, document],
         ['newline', '[id="\n"]', document],
         ['delete character', `[id="${String.fromCharCode(0x7f)}"]`, document],
+        ['space', '[id="with space"]', document],
+        ['other Unicode', '[id="emoji-😀"]', document],
         ['lone surrogate', `[id="${String.fromCharCode(0xd800)}"]`, document],
         ['detached Element', '[id="target"]', detached],
         ['DocumentFragment', '[id="target"]', fragment],

--- a/test/utility.test.js
+++ b/test/utility.test.js
@@ -2565,6 +2565,72 @@ describe('utility functions', () => {
     });
   });
 
+  describe('findByExactIdAttribute', () => {
+    const func = util.findByExactIdAttribute;
+
+    it('should find an exact ID in document and element contexts', () => {
+      const root = document.createElement('div');
+      const target = root.appendChild(document.createElement('span'));
+      target.id = 'base-ui-«r1»-label';
+      document.body.appendChild(root);
+      const selector = '[id="base-ui-«r1»-label"]';
+      assert.strictEqual(func(selector, document), target, 'Document');
+      assert.strictEqual(func(selector, root), target, 'Element');
+    });
+
+    it('should return null when the document has no matching ID', () => {
+      assert.strictEqual(func('[id="missing"]', document), null, 'result');
+      const root = document.body.appendChild(document.createElement('div'));
+      assert.strictEqual(func('[id="missing"]', root), null, 'Element');
+    });
+
+    it('should defer when the first document match cannot answer an element query', () => {
+      const outside = document.createElement('div');
+      outside.id = 'duplicate';
+      const root = document.createElement('div');
+      const inside = root.appendChild(document.createElement('span'));
+      inside.id = 'duplicate';
+      document.body.append(outside, root);
+      assert.strictEqual(
+        func('[id="duplicate"]', root),
+        undefined,
+        'first match outside context'
+      );
+
+      root.id = 'context';
+      assert.strictEqual(
+        func('[id="context"]', root),
+        undefined,
+        'context cannot select itself'
+      );
+    });
+
+    it('should defer unsupported selectors and query contexts', () => {
+      const detached = document.createElement('div');
+      const fragment = document.createDocumentFragment();
+      const host = document.body.appendChild(document.createElement('div'));
+      const shadow = host.attachShadow({ mode: 'open' });
+      const cases = [
+        ['empty value', '[id=""]', document],
+        ['escaped quote', '[id="quote\\"value"]', document],
+        ['escaped backslash', '[id="back\\\\slash"]', document],
+        ['unquoted value', '[id=target]', document],
+        ['single-quoted value', "[id='target']", document],
+        ['uppercase name', '[ID="target"]', document],
+        ['control character', `[id="${String.fromCharCode(0)}"]`, document],
+        ['lone surrogate', `[id="${String.fromCharCode(0xd800)}"]`, document],
+        ['detached Element', '[id="target"]', detached],
+        ['DocumentFragment', '[id="target"]', fragment],
+        ['ShadowRoot', '[id="target"]', shadow],
+        ['non-string selector', undefined, document],
+        ['invalid node', '[id="target"]', {}]
+      ];
+      for (const [label, selector, context] of cases) {
+        assert.strictEqual(func(selector, context), undefined, label);
+      }
+    });
+  });
+
   describe('findBySimpleAttribute', () => {
     const func = util.findBySimpleAttribute;
 

--- a/test/utility.test.js
+++ b/test/utility.test.js
@@ -2572,7 +2572,17 @@ describe('utility functions', () => {
       const root = document.createElement('div');
       const target = root.appendChild(document.createElement('span'));
       document.body.appendChild(root);
-      const ids = ['base-ui-«r1»-label', 'punctuation-[]='];
+      const ids = [
+        'foo',
+        'Foo',
+        'foo-bar',
+        'foo-bar_baz',
+        'foo-1-bar',
+        'foo-_bar-baz',
+        'foo-«bar»-baz',
+        'foo-«_bar»-baz',
+        'foo-«1»-bar'
+      ];
       for (const id of ids) {
         target.id = id;
         const selector = `[id="${id}"]`;
@@ -2615,9 +2625,15 @@ describe('utility functions', () => {
       const shadow = host.attachShadow({ mode: 'open' });
       const cases = [
         ['empty value', '[id=""]', document],
+        ['unquoted value', '[id=foo]', document],
+        ['qualified selector', 'a[id="foo"]', document],
+        ['leading digit', '[id="1-foo"]', document],
+        ['empty guillemets', '[id="foo-«»-bar"]', document],
+        ['hyphen in guillemets', '[id="foo-«bar-baz»-qux"]', document],
+        ['period', '[id="foo.bar"]', document],
+        ['braces', '[id="foo-{}-bar"]', document],
         ['escaped quote', '[id="quote\\"value"]', document],
         ['escaped backslash', '[id="back\\\\slash"]', document],
-        ['unquoted value', '[id=target]', document],
         ['single-quoted value', "[id='target']", document],
         ['uppercase name', '[ID="target"]', document],
         ['control character', `[id="${String.fromCharCode(0)}"]`, document],

--- a/types/js/utility.d.ts
+++ b/types/js/utility.d.ts
@@ -24,5 +24,6 @@ export declare const findBestSeed: (nodes: any[], state?: object) => object;
 export declare const populateHasAllowlist: (current: object, list: WeakSet<any>, visitedAncestors: Set<any>) => void;
 export declare const collectAllDescendants: (node: Document | DocumentFragment | Element, document: Document) => Array<Element>;
 export declare const hasAttributeLocalName: (node: Element, name: string) => boolean;
+export declare const findByExactIdAttribute: (selector: string, node: Document | DocumentFragment | Element) => Element | null | undefined;
 export declare const findBySimpleAttribute: (selector: string, node: Document | DocumentFragment | Element) => Array<Element> | null;
 export declare const getTraversalStrategy: (branch: Array<object>, targetType: string, hasScope: boolean, scoped: boolean) => object;


### PR DESCRIPTION
Testing Library resolves `aria-labelledby` references with selectors such as:

```js
container.querySelector(`[id="base-ui-«r1»-label"]`);
```

These currently use the general selector traversal. This adds a narrow `querySelector()` path for generated, double-quoted ID selectors matching this form, using `getElementById()`. Other exact ID shapes continue through the normal selector engine.

For element contexts, the result is used only when it is a descendant and is not the context itself. Duplicate IDs outside the context, detached and shadow trees, escaped values, and other selector forms continue through the normal selector engine.

The existing Testing Library benchmark resolves 24 references in a 5,858-element tree:

| Context | Main | This PR |
| --- | ---: | ---: |
| Document | 2.45 ms | 7.14 µs |
| Element | 2.55 ms | 13.50 µs |
| jsdom wrapper | 2.41 ms | 13.68 µs |

Fresh-process controls for ID, class, and unrelated attribute selectors were neutral.
