### PR TITLE
fix(matcher): Separate HTML attribute metadata cache

### DIFF
--- a/src/js/matcher.js
+++ b/src/js/matcher.js
@@ -34,6 +34,7 @@ const REG_ATTR_EQUALITY_NAME = /^[a-z][a-z0-9_-]*$/;
 
 /* cache */
 const astMetaCache = new WeakMap();
+const htmlAttrMetaCache = new WeakMap();
 
 /**
  * Validates a pseudo-element selector.
@@ -404,7 +405,8 @@ export const matchAttributeSelector = (
   }
   const astRawName = astName?.name;
   const isHTML = isHTMLElement(node);
-  let meta = astMetaCache.get(ast);
+  const metaCache = isHTML ? htmlAttrMetaCache : astMetaCache;
+  let meta = metaCache.get(ast);
   if (meta === undefined) {
     meta = {
       attrValues: new Set(),
@@ -421,7 +423,7 @@ export const matchAttributeSelector = (
     ) {
       meta.equalityName = astRawName;
     }
-    astMetaCache.set(ast, meta);
+    metaCache.set(ast, meta);
   }
   // Parsing and flag validation still run before this matching shortcut.
   if (isHTML && meta.equalityName !== null) {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1978,6 +1978,23 @@ describe('DOMSelector', () => {
         );
       }
     });
+
+    it('should keep attribute case rules separate for HTML and SVG', () => {
+      const root = document.createElement('div');
+      root.innerHTML =
+        '<input type="TEXT" data-probe><svg type="TEXT" data-probe></svg>';
+      document.body.appendChild(root);
+      const [input, svg] = root.children;
+      const domSelector = new DOMSelector(window);
+      const selector = '[type="text"][data-probe]';
+      const before = domSelector.querySelectorAll(selector, root);
+      assert.deepEqual(before, [input], 'HTML first');
+      root.prepend(svg);
+      domSelector.clear(true);
+      const after = domSelector.querySelectorAll(selector, root);
+      assert.deepEqual(after, [input], 'SVG first');
+    });
+
     it('should throw TypeError when querySelectorAll args missing', () => {
       assert.throws(
         () => new DOMSelector(window).querySelectorAll(),


### PR DESCRIPTION
Attribute queries across HTML and SVG can return different results depending on element order. For example, `[type="text"][data-probe]` can match an SVG element with `type="TEXT"`, or miss an HTML input with the same value.

Keeps HTML attribute matching rules in a separate cache so the first element visited doesn't determine how later elements match. Adds a regression for both element orders.
