### PR TITLE
perf(finder): Start attribute queries at their container

### DIFF
--- a/benchmark/bench-testing-library.js
+++ b/benchmark/bench-testing-library.js
@@ -209,4 +209,24 @@ group(`Attribute Equality After Mutations (Element)`, () => {
   });
 });
 
+const scopedWindow = new JSDOM('<!DOCTYPE html><body></body>').window;
+const scopedDocument = scopedWindow.document;
+const background = scopedDocument.createElement('aside');
+background.innerHTML = '<div><span></span></div>'.repeat(5000);
+const container = scopedDocument.createElement('main');
+container.innerHTML = '<div data-testid="target"><span></span></div>'.repeat(50);
+scopedDocument.body.append(background, container);
+const scopedSelector = new DOMSelector(scopedWindow);
+
+group(`Scoped Queries (100 elements after 10,000 unrelated elements)`, () => {
+  bench(`[data-testid="target"]`, () => {
+    scopedSelector.querySelectorAll('[data-testid="target"]', container);
+  });
+
+  bench(`[data-testid="target"], span`, () => {
+    scopedSelector.querySelectorAll('[data-testid="target"], span', container);
+  });
+});
+
 await run({ colors: true });
+scopedWindow.close();

--- a/src/js/finder.js
+++ b/src/js/finder.js
@@ -529,29 +529,18 @@ export class Finder extends Evaluator {
     if (!pendingItems.size) {
       return;
     }
-    if (!this.#rootWalker) {
-      this.#rootWalker = this.createTreeWalker(this.root);
-    }
     const node = this.#scoped ? this.node : this.root;
-    const walker = this.#rootWalker;
-    let nextNode = traverseNode(node, walker);
+    const walker = this.createTreeWalker(node, { force: true });
+    let nextNode = node;
     while (nextNode) {
-      const isWithinScope =
-        this.node.nodeType !== ELEMENT_NODE ||
-        nextNode === this.node ||
-        this.node.contains(nextNode);
-      if (isWithinScope) {
-        for (const pendingItem of pendingItems) {
-          const { leaves } = pendingItem.twig;
-          if (this.matchLeaves(leaves, nextNode, this.matchOpts)) {
-            const { index } = pendingItem;
-            this.#ast[index].filtered = true;
-            this.#ast[index].find = true;
-            this.#nodes[index].push(nextNode);
-          }
+      for (const pendingItem of pendingItems) {
+        const { leaves } = pendingItem.twig;
+        if (this.matchLeaves(leaves, nextNode, this.matchOpts)) {
+          const { index } = pendingItem;
+          this.#ast[index].filtered = true;
+          this.#ast[index].find = true;
+          this.#nodes[index].push(nextNode);
         }
-      } else if (this.#scoped) {
-        break;
       }
       nextNode = walker.nextNode();
     }

--- a/src/js/finder.js
+++ b/src/js/finder.js
@@ -17,6 +17,7 @@ import {
 
 /* constants */
 import {
+  ATTR_SELECTOR,
   CLASS_SELECTOR,
   DIR_NEXT,
   DIR_PREV,
@@ -508,7 +509,10 @@ export class Finder extends Evaluator {
     if (earlyResult) {
       return earlyResult;
     }
-    if (targetType === TARGET_FIRST) {
+    if (
+      targetType === TARGET_FIRST ||
+      (leaf.type === ATTR_SELECTOR && !compound)
+    ) {
       return this.#fallbackToWalkerResult(
         leaves,
         targetType,
@@ -529,18 +533,29 @@ export class Finder extends Evaluator {
     if (!pendingItems.size) {
       return;
     }
+    if (!this.#rootWalker) {
+      this.#rootWalker = this.createTreeWalker(this.root);
+    }
     const node = this.#scoped ? this.node : this.root;
-    const walker = this.createTreeWalker(node, { force: true });
-    let nextNode = node;
+    const walker = this.#rootWalker;
+    let nextNode = traverseNode(node, walker);
     while (nextNode) {
-      for (const pendingItem of pendingItems) {
-        const { leaves } = pendingItem.twig;
-        if (this.matchLeaves(leaves, nextNode, this.matchOpts)) {
-          const { index } = pendingItem;
-          this.#ast[index].filtered = true;
-          this.#ast[index].find = true;
-          this.#nodes[index].push(nextNode);
+      const isWithinScope =
+        this.node.nodeType !== ELEMENT_NODE ||
+        nextNode === this.node ||
+        this.node.contains(nextNode);
+      if (isWithinScope) {
+        for (const pendingItem of pendingItems) {
+          const { leaves } = pendingItem.twig;
+          if (this.matchLeaves(leaves, nextNode, this.matchOpts)) {
+            const { index } = pendingItem;
+            this.#ast[index].filtered = true;
+            this.#ast[index].find = true;
+            this.#nodes[index].push(nextNode);
+          }
         }
+      } else if (this.#scoped) {
+        break;
       }
       nextNode = walker.nextNode();
     }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1995,6 +1995,51 @@ describe('DOMSelector', () => {
       assert.deepEqual(after, [input], 'SVG first');
     });
 
+    it('should keep pending attribute queries within their context', () => {
+      const root = document.createElement('div');
+      root.innerHTML =
+        '<div data-container><span data-testid="target"></span></div>';
+      const container = root.firstElementChild;
+      const target = container.firstElementChild;
+      const before = target.cloneNode();
+      const after = target.cloneNode();
+      document.body.append(before, root, after);
+      const domSelector = new DOMSelector(window);
+      const cases = [
+        ['[data-testid="target"]', [target]],
+        ['[data-testid="target"], span', [target]],
+        [':scope, [data-testid="target"]', [target]],
+        ['[data-container] [data-testid="target"]', [target]],
+        ['body [data-testid="target"]', [target]]
+      ];
+      for (const [selector, expected] of cases) {
+        const res = domSelector.querySelectorAll(selector, container);
+        assert.deepEqual(res, expected, selector);
+      }
+      container.remove();
+      const detached = domSelector.querySelectorAll(
+        '[data-testid="target"]',
+        container
+      );
+      assert.deepEqual(detached, [target], 'detached context');
+    });
+
+    it('should keep pending attribute queries within a shadow root', () => {
+      const host = document.createElement('div');
+      document.body.appendChild(host);
+      const shadow = host.attachShadow({ mode: 'open' });
+      shadow.innerHTML =
+        '<span data-testid="target"></span><div><span data-testid="target"></span></div>';
+      const container = shadow.lastElementChild;
+      const target = container.firstElementChild;
+      const domSelector = new DOMSelector(window);
+      const res = domSelector.querySelectorAll(
+        '[data-testid="target"], span',
+        container
+      );
+      assert.deepEqual(res, [target], 'result');
+    });
+
     it('should throw TypeError when querySelectorAll args missing', () => {
       assert.throws(
         () => new DOMSelector(window).querySelectorAll(),

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1952,6 +1952,35 @@ describe('DOMSelector', () => {
   });
 
   describe('querySelectorAll', () => {
+    it('should match complex logical selectors across query contexts', () => {
+      document.body.innerHTML = `
+        <div id="container" class="container">
+          <div id="scope">
+            <div id="target" class="box">
+              <div class="parent"><div class="child"></div></div>
+            </div>
+          </div>
+        </div>`;
+      const container = document.getElementById('container');
+      const scope = document.getElementById('scope');
+      const target = document.getElementById('target');
+      const domSelector = new DOMSelector(window);
+      const cases = [
+        [document, ':is(.container .box)', [target]],
+        [scope, ':is(.container .box)', [target]],
+        [
+          document,
+          ':has(.parent .child)',
+          [document.documentElement, document.body, container, scope, target]
+        ],
+        [scope, ':has(.parent .child)', [target]]
+      ];
+      for (const [context, selector, expected] of cases) {
+        const res = domSelector.querySelectorAll(selector, context);
+        assert.deepEqual(res, expected, selector);
+      }
+    });
+
     it('should throw DOMException for invalid equality selectors', () => {
       const node = document.createElement('div');
       node.setAttribute('data-testid', 'target');


### PR DESCRIPTION
Routes single-attribute queries through the existing scoped walker, so queries within a container skip earlier parts of the document.

Querying `[data-testid="target"]` in a 100-element container; medians from five alternating runs against `main` (including #335 and #336):

| Preceding nodes | main | This PR | Speedup |
|---:|---:|---:|---:|
| 0 | 0.040 ms | 0.026 ms | 1.5x |
| 1,000 | 0.126 ms | 0.035 ms | 3.6x |
| 10,000 | 0.821 ms | 0.035 ms | 23.7x |

Adds cases to `bench:tl` and tests document and element queries with `:is(.container .box)` and `:has(.parent .child)`, along with detached containers and shadow roots.
