### PR TITLE
perf(finder): Stop closest searches at the nearest match

### DIFF
--- a/benchmark/bench-testing-library.js
+++ b/benchmark/bench-testing-library.js
@@ -228,5 +228,41 @@ group(`Scoped Queries (100 elements after 10,000 unrelated elements)`, () => {
   });
 });
 
+group('closest attribute ancestor', () => {
+  for (const depth of [20, 200]) {
+    for (const distance of [0, 1, 5, -1]) {
+      const container = document.createElement('div');
+      document.body.append(container);
+      let target = container;
+      const ancestors = [container];
+      for (let i = 0; i < depth; i++) {
+        const child = document.createElement('div');
+        target.append(child);
+        target = child;
+        ancestors.push(child);
+      }
+      const expected = distance < 0 ? null : ancestors.at(-1 - distance);
+      if (expected) {
+        expected.setAttribute('data-rootownerid', 'owner');
+      }
+      if (domSelector.closest('[data-rootownerid]', target) !== expected) {
+        throw new Error('Unexpected closest result');
+      }
+      bench(`closest [data-rootownerid] / depth ${depth} / distance ${distance}`, () => {
+        domSelector.closest('[data-rootownerid]', target);
+      });
+      if (distance === 1) {
+        let revision = false;
+        bench(`closest [data-rootownerid] after mutation / depth ${depth}`, () => {
+          revision = !revision;
+          target.setAttribute('data-revision', `${revision}`);
+          domSelector.clear();
+          domSelector.closest('[data-rootownerid]', target);
+        });
+      }
+    }
+  }
+});
+
 await run({ colors: true });
 scopedWindow.close();

--- a/src/js/finder.js
+++ b/src/js/finder.js
@@ -886,6 +886,9 @@ export class Finder extends Evaluator {
       while (currentNode) {
         if (this.matchLeaves(leaves, currentNode, this.matchOpts)) {
           nodes.push(currentNode);
+          if (!complex) {
+            break;
+          }
         }
         currentNode = currentNode.parentNode;
       }

--- a/test/finder.test.js
+++ b/test/finder.test.js
@@ -1458,5 +1458,40 @@ describe('Finder', () => {
       const res = finder.find('first');
       assert.deepEqual([...res], [], 'result');
     });
+
+    for (const [selector, ancestorIds] of [
+      ['[data-rootownerid]', ['inner']],
+      ['.container [data-rootownerid]', ['inner', 'outer']]
+    ]) {
+      it(`should check lineal ancestors for ${selector}`, () => {
+        document.body.innerHTML = `
+          <div class="container">
+            <div id="outer" data-rootownerid>
+              <div id="inner" data-rootownerid data-active>
+                <span id="target"></span>
+              </div>
+            </div>
+          </div>
+        `;
+        const finder = new Finder(window);
+        finder.setup(selector, document.getElementById('target'));
+        const spy = sinon.spy(finder, 'matchLeaves');
+        const res = finder.find('lineal');
+        assert.ok(res instanceof Set, 'returns a Set');
+        assert.strictEqual(res.size, 1, 'size');
+        assert.deepEqual(
+          [...res],
+          [document.getElementById('inner')],
+          'result'
+        );
+        for (const id of ['inner', 'outer']) {
+          assert.strictEqual(
+            spy.calledWith(sinon.match.any, document.getElementById(id)),
+            ancestorIds.includes(id),
+            `checks ${id}`
+          );
+        }
+      });
+    }
   });
 });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1044,6 +1044,76 @@ describe('DOMSelector', () => {
   });
 
   describe('closest', () => {
+    it('should find the nearest attribute match after mutations', () => {
+      document.body.innerHTML = `
+        <div id="outer" data-rootownerid>
+          <div id="inner" data-rootownerid data-active>
+            <span id="target"></span>
+          </div>
+        </div>`;
+      const outer = document.getElementById('outer');
+      const inner = document.getElementById('inner');
+      const target = document.getElementById('target');
+      const domSelector = new DOMSelector(window);
+
+      assert.strictEqual(
+        domSelector.closest('[data-rootownerid]', target),
+        inner
+      );
+      assert.strictEqual(
+        domSelector.closest('[data-rootownerid][data-active]', target),
+        inner
+      );
+      assert.strictEqual(
+        domSelector.closest('#outer, [data-rootownerid]', target),
+        inner
+      );
+
+      inner.removeAttribute('data-rootownerid');
+      domSelector.clear();
+      assert.strictEqual(
+        domSelector.closest('[data-rootownerid]', target),
+        outer
+      );
+      target.setAttribute('data-rootownerid', '');
+      domSelector.clear();
+      assert.strictEqual(
+        domSelector.closest('[data-rootownerid]', target),
+        target
+      );
+      assert.strictEqual(domSelector.closest('[data-missing]', target), null);
+    });
+
+    for (const context of ['document', 'detached', 'shadow']) {
+      it(`should keep searching for complex closest selectors in ${context}`, () => {
+        const container = document.createElement('section');
+        container.setAttribute('data-group', '');
+        container.innerHTML = `
+          <div data-owner>
+            <div>
+              <div data-owner><span></span></div>
+            </div>
+          </div>`;
+        if (context === 'document') {
+          document.body.appendChild(container);
+        } else if (context === 'shadow') {
+          const host = document.createElement('div');
+          document.body.appendChild(host);
+          host.attachShadow({ mode: 'open' }).appendChild(container);
+        }
+        const target = container.querySelector('span');
+        const domSelector = new DOMSelector(window);
+        assert.strictEqual(
+          domSelector.closest('[data-owner]', target),
+          target.parentElement
+        );
+        assert.strictEqual(
+          domSelector.closest('[data-group] > [data-owner]', target),
+          container.firstElementChild
+        );
+      });
+    }
+
     it('should throw DOMException for invalid equality selectors', () => {
       const node = document.createElement('div');
       node.setAttribute('data-testid', 'target');


### PR DESCRIPTION
Stop `closest()` at the first matching ancestor for selectors without combinators. Selectors with combinators still check farther candidates.

For Base UI's `[data-rootownerid]` selector on a 20-level jsdom tree:

| Match | main | This PR |
|---|---:|---:|
| Parent | 15.3–15.7 µs | 2.9–3.0 µs |
| Five ancestors up | 15.2–16.2 µs | 5.3–5.4 µs |
| Parent after mutation | 17.9 µs | 5.4 µs |

Warm timings span two runs in opposite order. The mutation row is one comparison including an unrelated attribute change and cache clear. Self matches and misses were roughly unchanged.
