### PR TITLE
perf(utility): Cache document type checks

### DIFF
--- a/src/js/utility.js
+++ b/src/js/utility.js
@@ -60,6 +60,9 @@ const REG_EXACT_ID_ATTRIBUTE =
   /^\[id="([A-Za-z]\w*(?:-(?:\w*|\u00AB\w+\u00BB))*)"\]$/;
 const REG_SIMPLE_ATTRIBUTE = /^\[([a-z][a-z\d_-]*)\]$/;
 
+/* cache */
+const htmlDocumentCache = new WeakMap();
+
 /**
  * Get type of an object.
  * @param {object} o - Object to check.
@@ -222,10 +225,12 @@ export const isHTMLElement = node => {
     return false;
   }
   const { namespaceURI, ownerDocument } = node;
-  return (
-    REG_IS_HTML.test(ownerDocument.contentType) &&
-    (!namespaceURI || namespaceURI === NS_HTML)
-  );
+  let isHTMLDocument = htmlDocumentCache.get(ownerDocument);
+  if (isHTMLDocument === undefined) {
+    isHTMLDocument = REG_IS_HTML.test(ownerDocument.contentType);
+    htmlDocumentCache.set(ownerDocument, isHTMLDocument);
+  }
+  return isHTMLDocument && (!namespaceURI || namespaceURI === NS_HTML);
 };
 
 /**

--- a/test/utility.test.js
+++ b/test/utility.test.js
@@ -381,6 +381,35 @@ describe('utility functions', () => {
   describe('is HTML element', () => {
     const func = util.isHTMLElement;
 
+    it('should read the document content type once for multiple elements', () => {
+      const contentType = document.contentType;
+      let reads = 0;
+      Object.defineProperty(document, 'contentType', {
+        get() {
+          reads++;
+          return contentType;
+        }
+      });
+      assert.strictEqual(func(document.createElement('div')), true);
+      assert.strictEqual(func(document.createElement('span')), true);
+      assert.strictEqual(reads, 1);
+    });
+
+    it('should keep namespaces and adopted documents separate', () => {
+      const xml = document.implementation.createDocument(null, 'root');
+      const html = document.createElement('div');
+      const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+      for (let i = 0; i < 2; i++) {
+        assert.strictEqual(func(html), true, 'HTML');
+        assert.strictEqual(func(svg), false, 'SVG');
+        assert.strictEqual(func(xml.documentElement), false, 'XML');
+      }
+      xml.adoptNode(html);
+      assert.strictEqual(func(html), false, 'HTML namespace in XML');
+      document.adoptNode(html);
+      assert.strictEqual(func(html), true, 'adopted back into HTML');
+    });
+
     it('should throw TypeError when node argument is undefined', () => {
       assert.throws(() => func(), TypeError, 'Unexpected type Undefined');
     });


### PR DESCRIPTION
Cache whether each document is HTML instead of reading `contentType` for every element during selector matching. Found this while profiling repeated queries in jsdom.

Benchmarks in jsdom with 250 rows, Node 26.8.1, median of three runs. The query pair runs `[data-testid]` and `[data-testid="row-249"]`.

| Query | Before | After |
| --- | ---: | ---: |
| Repeated attribute query pair | 299 µs | 187 µs |
| Attribute mutation + query pair | 309 µs | 192 µs |
| `div[data-testid] > span` | 256 µs | 150 µs |
| Testing Library `getByTestId()` after mutation | 152 µs | 153 µs |
