### PR TITLE
perf(evaluator): Reuse document type during selector matching

### DIFF
--- a/src/js/evaluator.js
+++ b/src/js/evaluator.js
@@ -92,8 +92,11 @@ export class Evaluator {
     this.check = !!check;
     this.noexcept = !!noexcept;
     this.warn = !!warn;
-    this.matchOpts = { warn: this.warn };
     [this.document, this.root, this.shadow] = resolveContent(node);
+    this.matchOpts = {
+      warn: this.warn,
+      isHTMLDocument: this.document.contentType === 'text/html'
+    };
     this.node = node;
     this.pseudoElements = [];
     this.invalidate = false;

--- a/src/js/finder.js
+++ b/src/js/finder.js
@@ -428,7 +428,7 @@ export class Finder extends Evaluator {
     if (
       targetType !== TARGET_FIRST &&
       !precede &&
-      this.document.contentType === 'text/html' &&
+      this.matchOpts.isHTMLDocument &&
       canUseFastTagSearch(this.node, tagName)
     ) {
       this.matchLeaves(leaves, this.node, this.matchOpts);
@@ -860,8 +860,8 @@ export class Finder extends Evaluator {
    */
   #matchSelf(leaves) {
     const matched = this.matchLeaves(leaves, this.node, {
-      check: this.check,
-      warn: this.warn
+      ...this.matchOpts,
+      check: this.check
     });
     const nodes = matched ? [this.node] : [];
     return [nodes, matched, this.pseudoElements];

--- a/src/js/matcher.js
+++ b/src/js/matcher.js
@@ -382,12 +382,13 @@ export const matchRequiredPseudoClass = (astName, node, keys) => {
  * @param {boolean} [opt.check] - True if running in an internal check.
  * @param {boolean} [opt.forgive] - True to forgive certain syntax errors.
  * @param {object} [opt.globalObject] - The global object.
+ * @param {boolean} [opt.isHTMLDocument] - True if the query document is HTML.
  * @returns {boolean} - True if the attribute selector matches, otherwise false.
  */
 export const matchAttributeSelector = (
   ast,
   node,
-  { check, forgive, globalObject } = {}
+  { check, forgive, globalObject, isHTMLDocument } = {}
 ) => {
   const {
     flags: astFlags,
@@ -404,7 +405,7 @@ export const matchAttributeSelector = (
     );
   }
   const astRawName = astName?.name;
-  const isHTML = isHTMLElement(node);
+  const isHTML = isHTMLElement(node, isHTMLDocument);
   const metaCache = isHTML ? htmlAttrMetaCache : astMetaCache;
   let meta = metaCache.get(ast);
   if (meta === undefined) {
@@ -728,12 +729,13 @@ export const matchAttributeSelector = (
  * @param {boolean} [opt.check] - True if running in an internal check.
  * @param {boolean} [opt.forgive] - True to forgive undeclared namespace.
  * @param {object} [opt.globalObject] - The global object.
+ * @param {boolean} [opt.isHTMLDocument] - True if the query document is HTML.
  * @returns {boolean} - True if the type selector matches, otherwise false.
  */
 export const matchTypeSelector = (
   ast,
   node,
-  { check, forgive, globalObject } = {}
+  { check, forgive, globalObject, isHTMLDocument } = {}
 ) => {
   const { localName, namespaceURI, prefix } = node;
   let meta = astMetaCache.get(ast);
@@ -754,7 +756,7 @@ export const matchTypeSelector = (
     meta.astLocalNameLowerCased = parsedLocalName.toLowerCase();
     meta.hasPipe = astName.includes('|');
   }
-  const isHTML = isHTMLElement(node);
+  const isHTML = isHTMLElement(node, isHTMLDocument);
   if (isHTML && localName === meta.astLocalName && !meta.hasPipe) {
     return true;
   }

--- a/src/js/utility.js
+++ b/src/js/utility.js
@@ -212,9 +212,10 @@ export const traverseNode = (node, walker, force = false) => {
 /**
  * Check if a node is an HTML element.
  * @param {Element} node - The Element node.
+ * @param {boolean} [isHTMLDocument] - True if the query document is HTML.
  * @returns {boolean} - True if it's the HTML element.
  */
-export const isHTMLElement = node => {
+export const isHTMLElement = (node, isHTMLDocument) => {
   if (!node?.nodeType) {
     throw new TypeError(`Unexpected type ${getType(node)}`);
   }
@@ -223,7 +224,7 @@ export const isHTMLElement = node => {
   }
   const { namespaceURI, ownerDocument } = node;
   return (
-    REG_IS_HTML.test(ownerDocument.contentType) &&
+    (isHTMLDocument ?? REG_IS_HTML.test(ownerDocument.contentType)) &&
     (!namespaceURI || namespaceURI === NS_HTML)
   );
 };

--- a/test/evaluator.test.js
+++ b/test/evaluator.test.js
@@ -187,6 +187,29 @@ describe('Evaluator', () => {
   });
 
   describe('setup evaluator', () => {
+    it('should read the document type once while matching multiple elements', () => {
+      const contentType = document.contentType;
+      let reads = 0;
+      Object.defineProperty(document, 'contentType', {
+        get() {
+          reads++;
+          return contentType;
+        }
+      });
+      const evaluator = new Evaluator(window).setup('div', document);
+      const ast = { type: TYPE_SELECTOR, name: 'div' };
+      for (const node of [
+        document.createElement('div'),
+        document.createElement('div')
+      ]) {
+        assert.strictEqual(
+          evaluator.matchSelector(ast, node, evaluator.matchOpts),
+          true
+        );
+      }
+      assert.strictEqual(reads, 1);
+    });
+
     it('should return self when setting up with a Document node', () => {
       const evaluator = new Evaluator(window);
       const res = evaluator.setup('*', document, {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -751,6 +751,22 @@ describe('DOMSelector', () => {
   });
 
   describe('matches', () => {
+    it('should reuse the document type while matching a compound selector', () => {
+      const domSelector = new DOMSelector(window);
+      const node = document.createElement('div');
+      node.setAttribute('data-kind', 'target');
+      const contentType = document.contentType;
+      let reads = 0;
+      Object.defineProperty(document, 'contentType', {
+        get() {
+          reads++;
+          return contentType;
+        }
+      });
+      assert.strictEqual(domSelector.matches('DIV[data-kind]', node), true);
+      assert.strictEqual(reads, 1);
+    });
+
     it('should throw DOMException for invalid equality selectors', () => {
       const node = document.createElement('div');
       node.setAttribute('data-testid', 'target');
@@ -1952,6 +1968,43 @@ describe('DOMSelector', () => {
   });
 
   describe('querySelectorAll', () => {
+    it('should keep HTML and SVG case matching separate within a query', () => {
+      const domSelector = new DOMSelector(window);
+      const parent = document.createElement('section');
+      parent.innerHTML =
+        '<g data-kind="target"></g><svg><g data-kind="target"></g></svg>';
+      const html = parent.firstElementChild;
+      const svg = parent.lastElementChild.firstElementChild;
+      assert.deepEqual(domSelector.querySelectorAll('G[data-kind]', parent), [
+        html
+      ]);
+      assert.deepEqual(domSelector.querySelectorAll('g[data-kind]', parent), [
+        html,
+        svg
+      ]);
+      assert.deepEqual(
+        domSelector.querySelectorAll(':is(G)[data-kind]', parent),
+        [html]
+      );
+    });
+
+    it('should use the current document type after adopting an element', () => {
+      const domSelector = new DOMSelector(window);
+      const xml = document.implementation.createDocument(null, 'root');
+      const parent = document.createElement('section');
+      const node = document.createElement('div');
+      node.setAttribute('data-kind', 'target');
+      parent.appendChild(node);
+      const selector = 'DIV[data-kind]';
+      assert.deepEqual(domSelector.querySelectorAll(selector, parent), [node]);
+      xml.adoptNode(parent);
+      domSelector.clear();
+      assert.deepEqual(domSelector.querySelectorAll(selector, parent), []);
+      document.adoptNode(parent);
+      domSelector.clear();
+      assert.deepEqual(domSelector.querySelectorAll(selector, parent), [node]);
+    });
+
     it('should match complex logical selectors across query contexts', () => {
       document.body.innerHTML = `
         <div id="container" class="container">

--- a/types/js/evaluator.d.ts
+++ b/types/js/evaluator.d.ts
@@ -8,6 +8,7 @@ export declare class Evaluator {
     warn: boolean | undefined;
     matchOpts: {
         warn: boolean;
+        isHTMLDocument: boolean;
     } | undefined;
     node: Document | DocumentFragment | Element | undefined;
     pseudoElements: any[] | undefined;

--- a/types/js/matcher.d.ts
+++ b/types/js/matcher.d.ts
@@ -12,13 +12,15 @@ export declare const matchPlaceholderShownPseudoClass: (node: Element, keys: Set
 export declare const matchRangePseudoClass: (astName: string, node: Element, keys: Set<string>) => boolean;
 export declare const matchReadOnlyPseudoClass: (astName: string, node: Element) => boolean;
 export declare const matchRequiredPseudoClass: (astName: string, node: Element, keys: Set<string>) => boolean;
-export declare const matchAttributeSelector: (ast: import('css-tree').CssNode, node: Element, { check, forgive, globalObject }?: {
+export declare const matchAttributeSelector: (ast: import('css-tree').CssNode, node: Element, { check, forgive, globalObject, isHTMLDocument }?: {
     check?: boolean;
     forgive?: boolean;
     globalObject?: object;
+    isHTMLDocument?: boolean;
 }) => boolean;
-export declare const matchTypeSelector: (ast: import('css-tree').CssNode, node: Element, { check, forgive, globalObject }?: {
+export declare const matchTypeSelector: (ast: import('css-tree').CssNode, node: Element, { check, forgive, globalObject, isHTMLDocument }?: {
     check?: boolean;
     forgive?: boolean;
     globalObject?: object;
+    isHTMLDocument?: boolean;
 }) => boolean;

--- a/types/js/utility.d.ts
+++ b/types/js/utility.d.ts
@@ -3,7 +3,7 @@ export declare const verifyArray: (arr: any[], type: string) => any[];
 export declare const generateException: (msg: string, name: string, globalObject?: object) => DOMException;
 export declare const resolveContent: (node: Document | DocumentFragment | Element) => Array<Document | DocumentFragment | Element | boolean>;
 export declare const traverseNode: (node: Element, walker: TreeWalker, force?: boolean) => Element | null;
-export declare const isHTMLElement: (node: Element) => boolean;
+export declare const isHTMLElement: (node: Element, isHTMLDocument?: boolean) => boolean;
 export declare const isCustomElement: (node: Element, { formAssociated }?: {
     formAssociated?: boolean;
 }) => boolean;


### PR DESCRIPTION
Read the document type once per query and reuse it during selector matching. Each element still checks its own namespace, and each new query uses its current document.

Found while profiling selector queries in jsdom. These benchmarks use 250-row selector fixtures and a 14-field React form (Node 26.8.1, median of three runs). The query pair runs `[data-testid]` and `[data-testid="row-249"]`.

| Workload | Before | After |
| --- | ---: | ---: |
| Repeated attribute query pair | 297 µs | 186 µs |
| Attribute mutation + query pair | 308 µs | 190 µs |
| Testing Library lookup after mutation | 156 µs | 161 µs |
| React form mount/unmount | 2.75 ms | 2.76 ms |

The broader Testing Library and React benchmarks did not show a reliable improvement.
