### PR TITLE
perf(selector): Speed up single attribute matches

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -8,6 +8,7 @@
 /* import */
 import { LRUCache } from 'lru-cache';
 import { Finder } from './js/finder.js';
+import { matchAttributeSelector } from './js/matcher.js';
 import { Nwsapi } from './js/nwsapi.js';
 import { extractSubjectsAst, parseSelector } from './js/parser.js';
 import {
@@ -24,6 +25,7 @@ import {
 
 /* constants */
 import {
+  ATTR_SELECTOR,
   DOCUMENT_NODE,
   ELEMENT_NODE,
   MIME_HTML,
@@ -36,6 +38,7 @@ const CACHE_SIZE = 4096;
 
 /* regexp */
 const REG_SELECTOR = /[[\]():\\"'`]/;
+const REG_ATTRIBUTE = /^\[[\s\S]*\]$/;
 const REG_UNIVERSAL = /^\s*(?:\*\|)?\*\s*$/;
 
 /**
@@ -225,6 +228,30 @@ export class DOMSelector {
     if (nwsapiRes.success) {
       return nwsapiRes.result;
     }
+    if (typeof selector === 'string' && REG_ATTRIBUTE.test(selector)) {
+      try {
+        const cacheKey = `attribute_match_${selector}`;
+        let ast = this.#cache.get(cacheKey);
+        if (ast === undefined) {
+          const list = parseSelector(selector);
+          const child = list.children.first;
+          ast =
+            list.children.size === 1 &&
+            child.children.size === 1 &&
+            child.children.first.type === ATTR_SELECTOR
+              ? child.children.first
+              : null;
+          this.#cache.set(cacheKey, ast);
+        }
+        if (ast !== null) {
+          return matchAttributeSelector(ast, node, {
+            globalObject: this.#window
+          });
+        }
+      } catch {
+        // Let Finder handle invalid selectors and error options.
+      }
+    }
     const nodes = this.#findNodes(selector, node, opt, TARGET_SELF);
     return !!(nodes && nodes.size > 0);
   }
@@ -361,6 +388,15 @@ export class DOMSelector {
    * @returns {{success: boolean, result: Array<Element>|Element|boolean|null}} An object indicating whether the execution succeeded and its result.
    */
   #tryNwsapi(selector, node, targetType, callback, isCheck = false) {
+    const cacheKey = `${isCheck ? 'check' : targetType}_${selector}`;
+    let filterMatches = this.#cache.get(cacheKey);
+    if (filterMatches === undefined) {
+      filterMatches = filterSelector(selector, targetType);
+      this.#cache.set(cacheKey, filterMatches);
+    }
+    if (!filterMatches) {
+      return { result: null, success: false };
+    }
     const document = node.ownerDocument;
     // jsdom passes an internal document to the constructor but wraps entry nodes.
     if (
@@ -370,19 +406,11 @@ export class DOMSelector {
       document.contentType === MIME_HTML &&
       document.documentElement
     ) {
-      const cacheKey = `${isCheck ? 'check' : targetType}_${selector}`;
-      let filterMatches = this.#cache.get(cacheKey);
-      if (filterMatches === undefined) {
-        filterMatches = filterSelector(selector, targetType);
-        this.#cache.set(cacheKey, filterMatches);
-      }
-      if (filterMatches) {
-        try {
-          const result = callback(node);
-          return { result, success: true };
-        } catch {
-          // fall through
-        }
+      try {
+        const result = callback(node);
+        return { result, success: true };
+      } catch {
+        // fall through
       }
     }
     return { result: null, success: false };

--- a/src/index.js
+++ b/src/index.js
@@ -10,7 +10,11 @@ import { LRUCache } from 'lru-cache';
 import { Finder } from './js/finder.js';
 import { matchAttributeSelector } from './js/matcher.js';
 import { Nwsapi } from './js/nwsapi.js';
-import { extractSubjectsAst, parseSelector } from './js/parser.js';
+import {
+  extractSubjectsAst,
+  parseSelector,
+  parseSingleAttributeSelector
+} from './js/parser.js';
 import {
   extractSubjectsRegExp,
   filterSelector,
@@ -25,7 +29,6 @@ import {
 
 /* constants */
 import {
-  ATTR_SELECTOR,
   DOCUMENT_NODE,
   ELEMENT_NODE,
   MIME_HTML,
@@ -233,14 +236,7 @@ export class DOMSelector {
         const cacheKey = `attribute_match_${selector}`;
         let ast = this.#cache.get(cacheKey);
         if (ast === undefined) {
-          const list = parseSelector(selector);
-          const child = list.children.first;
-          ast =
-            list.children.size === 1 &&
-            child.children.size === 1 &&
-            child.children.first.type === ATTR_SELECTOR
-              ? child.children.first
-              : null;
+          ast = parseSingleAttributeSelector(selector);
           this.#cache.set(cacheKey, ast);
         }
         if (ast !== null) {

--- a/src/js/parser.js
+++ b/src/js/parser.js
@@ -227,6 +227,24 @@ export const parseSelector = (sel, context = 'selectorList') => {
 };
 
 /**
+ * Parses a selector containing only one attribute selector.
+ * @param {string} selector - The CSS selector string.
+ * @returns {import('css-tree').CssNode|null} The attribute AST, or null for other selectors.
+ */
+export const parseSingleAttributeSelector = selector => {
+  const list = parseSelector(selector);
+  const child = list.children.first;
+  if (
+    list.children.size === 1 &&
+    child.children.size === 1 &&
+    child.children.first.type === ATTR_SELECTOR
+  ) {
+    return child.children.first;
+  }
+  return null;
+};
+
+/**
  * Walks the provided AST to collect selector branches and gather information
  * about its contents.
  * @param {import('css-tree').CssNode} ast - The AST to traverse.

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -12,6 +12,7 @@ import * as cssTree from 'css-tree';
 
 /* test */
 import { DOMSelector } from '../src/index.js';
+import { Finder } from '../src/js/finder.js';
 /* constants */
 import { SYNTAX_ERR } from '../src/js/constant.js';
 
@@ -1018,6 +1019,44 @@ describe('DOMSelector', () => {
         noexcept: true
       });
       assert.strictEqual(res, false, 'result');
+    });
+
+    it('should skip Finder setup for a single attribute selector', () => {
+      const engine = new DOMSelector(window);
+      const node = document.createElement('div');
+      node.setAttribute('data-state', 'ready');
+      const setup = sinon.spy(Finder.prototype, 'setup');
+      try {
+        assert.strictEqual(engine.matches('[data-state="ready"]', node), true);
+        node.removeAttribute('data-state');
+        assert.strictEqual(engine.matches('[data-state="ready"]', node), false);
+        assert.strictEqual(setup.callCount, 0);
+      } finally {
+        setup.restore();
+      }
+    });
+
+    it('should use Finder for compound selectors and invalid attributes', () => {
+      const engine = new DOMSelector(window);
+      const node = document.createElement('div');
+      node.setAttribute('data-state', 'ready');
+      node.setAttribute('data-other', '');
+      const setup = sinon.spy(Finder.prototype, 'setup');
+      try {
+        assert.strictEqual(
+          engine.matches('[data-state][data-other]', node),
+          true
+        );
+        assert.strictEqual(setup.callCount, 1);
+        assert.throws(
+          () => engine.matches('[data-state="ready" q]', node),
+          error =>
+            error instanceof window.DOMException && error.name === SYNTAX_ERR
+        );
+        assert.strictEqual(setup.callCount, 2);
+      } finally {
+        setup.restore();
+      }
     });
 
     it('should reevaluate attribute matches after mutations and cache clearing', () => {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1020,6 +1020,101 @@ describe('DOMSelector', () => {
       assert.strictEqual(res, false, 'result');
     });
 
+    it('should reevaluate attribute matches after mutations and cache clearing', () => {
+      const engine = new DOMSelector(window);
+      const node = document.createElement('div');
+      const selector = '[data-state="ready"]';
+      assert.strictEqual(engine.matches(selector, node), false);
+      node.setAttribute('data-state', 'ready');
+      assert.strictEqual(engine.matches(selector, node), true);
+      node.setAttribute('data-state', 'waiting');
+      assert.strictEqual(engine.matches(selector, node), false);
+      node.setAttribute('data-state', 'ready');
+      engine.clear();
+      assert.strictEqual(engine.matches(selector, node), true);
+      engine.clear(true);
+      node.removeAttribute('data-state');
+      assert.strictEqual(engine.matches(selector, node), false);
+    });
+
+    it('should preserve attribute operators, escaping and case flags', () => {
+      const engine = new DOMSelector(window);
+      const node = document.createElement('div');
+      node.setAttribute('data-state', 'Ready now');
+      for (const [selector, expected] of [
+        ['[data-state]', true],
+        ['[data\\-state]', true],
+        ['[data-state="ready now" i]', true],
+        ['[data-state="ready now" s]', false],
+        ['[data-state~="now"]', true],
+        ['[data-state^="Ready"]', true],
+        ['[data-state$="now"]', true],
+        ['[data-state*="dy n"]', true],
+        ['[data-state|="Ready"]', false],
+        ['[data-state^=""]', false],
+        ['[data-state][data-other]', false],
+        ['[data-other], [data-state]', true],
+        ['[data-state] > [data-state]', false]
+      ]) {
+        assert.strictEqual(engine.matches(selector, node), expected, selector);
+        assert.strictEqual(engine.matches(selector, node), expected, selector);
+      }
+    });
+
+    it('should match namespaced attributes in a shadow tree', () => {
+      const engine = new DOMSelector(window);
+      const host = document.createElement('div');
+      const root = host.attachShadow({ mode: 'closed' });
+      const node = document.createElementNS(
+        'http://www.w3.org/2000/svg',
+        'svg'
+      );
+      node.setAttributeNS('urn:test', 'test:data-state', 'ready');
+      root.append(node);
+      for (const selector of ['[data-state]', '[*|data-state="ready"]']) {
+        assert.strictEqual(engine.matches(selector, node), true, selector);
+        document.body.append(host);
+        assert.strictEqual(engine.matches(selector, node), true, selector);
+        host.remove();
+      }
+    });
+
+    it('should preserve XML attribute case with a reused selector', () => {
+      const engine = new DOMSelector(window);
+      const xml = new window.DOMParser().parseFromString(
+        '<root/>',
+        'application/xml'
+      );
+      const node = xml.documentElement;
+      const htmlNode = document.createElement('div');
+      htmlNode.setAttribute('data-state', 'ready');
+      node.setAttribute('DATA-STATE', 'ready');
+      for (let i = 0; i < 2; i++) {
+        assert.strictEqual(engine.matches('[data-state]', htmlNode), true);
+        assert.strictEqual(engine.matches('[data-state]', node), false);
+        assert.strictEqual(engine.matches('[DATA-STATE]', node), true);
+      }
+    });
+
+    it('should throw attribute syntax errors after a noexcept call', () => {
+      const engine = new DOMSelector(window);
+      for (const selector of [
+        '[]',
+        '[data-state="ready" q]',
+        '[data-state="ready]'
+      ]) {
+        assert.strictEqual(
+          engine.matches(selector, document.body, { noexcept: true }),
+          false
+        );
+        assert.throws(
+          () => engine.matches(selector, document.body),
+          error =>
+            error instanceof window.DOMException && error.name === SYNTAX_ERR
+        );
+      }
+    });
+
     it('should return false for empty selector with noexcept', () => {
       const domSelector = new DOMSelector(window);
       const res = domSelector.matches('', document.body, {

--- a/test/parser.test.js
+++ b/test/parser.test.js
@@ -31,6 +31,56 @@ const AN_PLUS_B = 'AnPlusB';
 const RAW = 'Raw';
 const SELECTOR_LIST = 'SelectorList';
 
+describe('parse single attribute selector', () => {
+  it('should return the attribute AST with its value and flags', () => {
+    const ast = parser.parseSingleAttributeSelector('[data-state="ready" i]');
+    assert.strictEqual(ast.type, ATTR_SELECTOR);
+    assert.strictEqual(ast.name.name, 'data-state');
+    assert.strictEqual(ast.matcher, '=');
+    assert.strictEqual(ast.value.value, 'ready');
+    assert.strictEqual(ast.flags, 'i');
+  });
+
+  it('should accept escaped and namespaced attribute names', () => {
+    for (const selector of [
+      '[data\\-state]',
+      '[*|data-state]',
+      ' [data-state] '
+    ]) {
+      const ast = parser.parseSingleAttributeSelector(selector);
+      assert.strictEqual(ast.type, ATTR_SELECTOR, selector);
+      assert.strictEqual(ast.matcher, null, selector);
+    }
+  });
+
+  it('should return null for other selector shapes', () => {
+    for (const selector of [
+      '*',
+      '.ready',
+      'div[data-state]',
+      '[data-state][data-other]',
+      '[data-state], [data-other]',
+      '[data-state] > [data-other]',
+      '[data-state]:is([data-other])'
+    ]) {
+      assert.strictEqual(
+        parser.parseSingleAttributeSelector(selector),
+        null,
+        selector
+      );
+    }
+  });
+
+  it('should preserve parser errors for malformed selectors', () => {
+    for (const selector of ['[]', '[data-state=]']) {
+      assert.throws(
+        () => parser.parseSingleAttributeSelector(selector),
+        error => error.name === SYNTAX_ERR
+      );
+    }
+  });
+});
+
 describe('unescape selector', () => {
   const func = parser.unescapeSelector;
 

--- a/types/js/parser.d.ts
+++ b/types/js/parser.d.ts
@@ -1,6 +1,7 @@
 export declare const unescapeSelector: (selector?: string) => string;
 export declare const preprocess: (value: string) => string;
 export declare const parseSelector: (sel: string, context?: string) => import('css-tree').CssNode;
+export declare const parseSingleAttributeSelector: (selector: string) => import('css-tree').CssNode | null;
 export declare const walkAST: (ast?: import('css-tree').CssNode, toObject?: boolean, callback?: (node: import('css-tree').CssNode) => void) => {
     branches: Array<Array<import('css-tree').CssNode>>;
     info: object;


### PR DESCRIPTION
Single attribute selectors such as `[data-testid]` go through Finder setup even though they only need to check one element. Parse and cache those selectors, then reuse the existing attribute matcher. Other selectors and invalid input keep the existing fallback.

Also check cached Nwsapi eligibility before reading DOM context, avoiding that work for selectors it cannot handle.

Benchmarks in jsdom on Node 26.8.1, comparing against main (`f2ff18a`). Times are means across two runs, reversing the order for the repeat. The cold case measures 5,000 distinct selectors after warming the engine.

| Workload | Before | After |
|---|---:|---:|
| Repeated `matches("[data-testid]")` | 2.01 µs | 0.58 µs |
| Repeated `matches(".row")` | 0.61 µs | 0.64 µs |
| Repeated `matches("[class]")` | 0.60 µs | 0.62 µs |
| First-time compound attribute selector | 9.32 µs | 11.38 µs |

Keeping this in draft because first-time compound selectors such as `[data-other][data-missing="value"]` currently take about 22% longer. The shortcut parses them to determine they are ineligible, then Finder parses them again. Repeated calls cache that decision, but the duplicate work on the first call still needs addressing.
