### PR TITLE
Use internal DOM access for attribute selectors

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,13 @@ Creates an instance of the DOMSelector.
 * `opt` **{object}?** Options:
   * `opt.cacheSize` **{number}?** Maximum number of items to store in the internal cache. Default is 2048.
 
+DOM implementations can additionally supply `idlUtils` (`wrapperForImpl` and
+`implForWrapper`) and `domSymbolTree` for internal node access. With `idlUtils`,
+`getAttributeList(elementImpl)` can return the implementation's attribute list.
+Its entries expose `name`, `value`, `namespaceURI`, and `localName`, as on `Attr`.
+The selector engine reads this list without modifying it. When the callback is
+omitted, attribute-list matching uses the public `attributes` collection.
+
 ### `matches(selector, node, opt?)`
 
 Equivalent to [Element.matches()](https://developer.mozilla.org/docs/Web/API/Element/matches).

--- a/benchmark/bench-testing-library.js
+++ b/benchmark/bench-testing-library.js
@@ -4,6 +4,7 @@
 import { run, bench, group } from 'mitata';
 import { JSDOM } from 'jsdom';
 import idlUtils from 'jsdom/lib/generated/idl/utils.js';
+import internalConstants from 'jsdom/lib/jsdom/living/helpers/internal-constants.js';
 import { DOMSelector } from '../src/index.js';
 
 const DEPTH = 4;
@@ -75,7 +76,9 @@ const totalElements = document.querySelectorAll('*').length;
 const domSelector = new DOMSelector(window);
 const documentImpl = idlUtils.implForWrapper(document);
 const jsdomSelector = new DOMSelector(window, documentImpl, {
-  idlUtils
+  idlUtils,
+  domSymbolTree: internalConstants.domSymbolTree,
+  getAttributeList: element => element._attributeList
 });
 const rootImpl = idlUtils.implForWrapper(root);
 const implicitRoleCandidates = [...document.querySelectorAll('input')].map(

--- a/src/index.js
+++ b/src/index.js
@@ -52,6 +52,7 @@ export class DOMSelector {
   #document;
   #finder;
   #idlUtils;
+  #domSymbolTree;
   #nwsapi;
   #cache;
 
@@ -62,14 +63,15 @@ export class DOMSelector {
    * @param {object} [opt] - Options.
    */
   constructor(window, document, opt = {}) {
-    const { cacheSize, idlUtils } = opt;
+    const { cacheSize, idlUtils, domSymbolTree, getAttributeList } = opt;
     this.#window = window;
     this.#document = document ?? window.document;
     this.#idlUtils = idlUtils;
+    this.#domSymbolTree = domSymbolTree;
     this.#cache = new LRUCache({
       max: cacheSize ?? CACHE_SIZE
     });
-    this.#finder = new Finder(this.#window);
+    this.#finder = new Finder(this.#window, { idlUtils, getAttributeList });
     this.#nwsapi = new Nwsapi(this.#window, this.#document, cacheSize);
   }
 
@@ -312,7 +314,12 @@ export class DOMSelector {
         node.nodeType === DOCUMENT_NODE ? node : node.ownerDocument;
       return collectAllDescendants(node, document);
     }
-    const fastNodes = findBySimpleAttribute(selector, node);
+    const fastNodes = findBySimpleAttribute(
+      selector,
+      node,
+      this.#idlUtils,
+      this.#domSymbolTree
+    );
     if (Array.isArray(fastNodes)) {
       return fastNodes;
     }

--- a/src/js/evaluator.js
+++ b/src/js/evaluator.js
@@ -38,6 +38,8 @@ const KEYS_UNCACHE = new Set(['any-link', 'defined', 'dir', 'link', 'scope']);
 export class Evaluator {
   /* private fields */
   #domTraverser;
+  #idlUtils;
+  #getAttributeList;
   #eventHandler;
   #filterLeavesCache;
   #invalidateResults;
@@ -49,8 +51,13 @@ export class Evaluator {
 
   /**
    * @param {Window} window - The window object.
+   * @param {object} [opt] - Internal DOM access options.
+   * @param {object} [opt.idlUtils] - Optional implementation/wrapper utilities.
+   * @param {import('./matcher.js').GetAttributeList} [opt.getAttributeList] - Reads the attributes of an element implementation.
    */
-  constructor(window) {
+  constructor(window, { idlUtils, getAttributeList } = {}) {
+    this.#getAttributeList = getAttributeList;
+    this.#idlUtils = idlUtils;
     this.window = window;
     this.documentCache = new WeakMap();
     this.#domTraverser = new DOMTraverser(this);
@@ -351,7 +358,13 @@ export class Evaluator {
     const { type: astType } = ast;
     switch (astType) {
       case ATTR_SELECTOR: {
-        return matchAttributeSelector(ast, node, opt);
+        return matchAttributeSelector(
+          ast,
+          node,
+          opt,
+          this.#idlUtils?.implForWrapper?.(node),
+          this.#getAttributeList
+        );
       }
       case ID_SELECTOR: {
         return node.id === this.getUnescapedName(ast);

--- a/src/js/matcher.js
+++ b/src/js/matcher.js
@@ -37,6 +37,21 @@ const astMetaCache = new WeakMap();
 const htmlAttrMetaCache = new WeakMap();
 
 /**
+ * Attribute data supplied by a DOM implementation.
+ * @typedef {object} AttributeData
+ * @property {string} name - Qualified attribute name.
+ * @property {string} value - Attribute value.
+ * @property {string|null} namespaceURI - Attribute namespace.
+ * @property {string} localName - Attribute local name.
+ */
+
+/**
+ * @callback GetAttributeList
+ * @param {object} element - Unwrapped element implementation.
+ * @returns {readonly AttributeData[]} The element's attributes, in order.
+ */
+
+/**
  * Validates a pseudo-element selector.
  * @param {string} astName - The name of the pseudo-element from the AST.
  * @param {string} astType - The type of the selector from the AST.
@@ -382,12 +397,16 @@ export const matchRequiredPseudoClass = (astName, node, keys) => {
  * @param {boolean} [opt.check] - True if running in an internal check.
  * @param {boolean} [opt.forgive] - True to forgive certain syntax errors.
  * @param {object} [opt.globalObject] - The global object.
+ * @param {object} [impl] - Optional element implementation.
+ * @param {GetAttributeList} [getAttributeList] - Reads implementation attributes.
  * @returns {boolean} - True if the attribute selector matches, otherwise false.
  */
 export const matchAttributeSelector = (
   ast,
   node,
-  { check, forgive, globalObject } = {}
+  { check, forgive, globalObject } = {},
+  impl,
+  getAttributeList
 ) => {
   const {
     flags: astFlags,
@@ -404,7 +423,8 @@ export const matchAttributeSelector = (
     );
   }
   const astRawName = astName?.name;
-  const isHTML = isHTMLElement(node);
+  const attrNode = impl ?? node;
+  const isHTML = isHTMLElement(attrNode);
   const metaCache = isHTML ? htmlAttrMetaCache : astMetaCache;
   let meta = metaCache.get(ast);
   if (meta === undefined) {
@@ -428,13 +448,13 @@ export const matchAttributeSelector = (
   // Parsing and flag validation still run before this matching shortcut.
   if (isHTML && meta.equalityName !== null) {
     const attrName = meta.equalityName;
-    if (node.getAttribute(attrName) === astValue.value) {
+    if (attrNode.getAttribute(attrName) === astValue.value) {
       return true;
     }
     // Prefixed or duplicate names can hide another matching attribute.
     let occurrences = 0;
     let needsFallback = false;
-    for (const attributeName of node.getAttributeNames()) {
+    for (const attributeName of attrNode.getAttributeNames()) {
       if (attributeName === attrName) {
         occurrences++;
       }
@@ -456,14 +476,15 @@ export const matchAttributeSelector = (
     if (!meta.hasPipe) {
       if (
         meta.astName === 'lang' &&
-        node.hasAttributeNS('http://www.w3.org/XML/1998/namespace', 'lang')
+        attrNode.hasAttributeNS('http://www.w3.org/XML/1998/namespace', 'lang')
       ) {
         return false;
       }
-      if (node.hasAttribute(meta.astName)) {
+      if (attrNode.hasAttribute(meta.astName)) {
         return true;
       }
-      const attrs = node.attributes;
+      const attrs =
+        impl && getAttributeList ? getAttributeList(impl) : node.attributes;
       if (!attrs || attrs.length === 0) {
         return false;
       }
@@ -488,7 +509,8 @@ export const matchAttributeSelector = (
       return false;
     }
   }
-  const { attributes } = node;
+  const attributes =
+    impl && getAttributeList ? getAttributeList(impl) : node.attributes;
   if (!attributes || !attributes.length) {
     return false;
   }

--- a/src/js/utility.js
+++ b/src/js/utility.js
@@ -996,9 +996,16 @@ export const findByExactIdAttribute = (selector, node) => {
  * Finds descendants for simple attribute-presence selectors.
  * @param {string} selector - The CSS selector to match against.
  * @param {Document|DocumentFragment|Element} node - The node to find within.
+ * @param {object} [idlUtils] - Optional implementation/wrapper utilities.
+ * @param {object} [domSymbolTree] - Optional jsdom internal tree.
  * @returns {Array<Element>|null} Matching elements, or `null` when this function does not apply.
  */
-export const findBySimpleAttribute = (selector, node) => {
+export const findBySimpleAttribute = (
+  selector,
+  node,
+  idlUtils,
+  domSymbolTree
+) => {
   if (typeof selector !== 'string') {
     return null;
   }
@@ -1026,11 +1033,30 @@ export const findBySimpleAttribute = (selector, node) => {
   if (document.contentType !== MIME_HTML) {
     return null;
   }
+  if (idlUtils?.implForWrapper && domSymbolTree) {
+    const root = idlUtils.implForWrapper(node);
+    const nodes = [];
+    for (const candidate of domSymbolTree.treeIterator(root)) {
+      if (
+        candidate !== root &&
+        candidate.nodeType === ELEMENT_NODE &&
+        hasAttributeLocalName(candidate, name)
+      ) {
+        nodes.push(idlUtils.wrapperForImpl(candidate));
+      }
+    }
+    return nodes;
+  }
   const walker = document.createTreeWalker(node, SHOW_ELEMENT);
   const nodes = [];
   let nextNode = walker.nextNode();
   while (nextNode) {
-    if (hasAttributeLocalName(nextNode, name)) {
+    if (
+      hasAttributeLocalName(
+        idlUtils?.implForWrapper ? idlUtils.implForWrapper(nextNode) : nextNode,
+        name
+      )
+    ) {
       nodes.push(nextNode);
     }
     nextNode = walker.nextNode();

--- a/test/internal-attributes.test.js
+++ b/test/internal-attributes.test.js
@@ -1,0 +1,324 @@
+import { strict as assert } from 'node:assert';
+import { JSDOM } from 'jsdom';
+import idlUtils from 'jsdom/lib/generated/idl/utils.js';
+import internalConstants from 'jsdom/lib/jsdom/living/helpers/internal-constants.js';
+import { describe, it } from 'mocha';
+import { DOMSelector } from '../src/index.js';
+
+const { domSymbolTree } = internalConstants;
+const getAttributeList = element => element._attributeList;
+
+const selectors = [
+  '[data-testid]',
+  '[data-testid="target"]',
+  '[data-testid="missing"]',
+  '[data-testid^="tar"]',
+  '[data-testid$="get"]',
+  '[data-testid*="arg"]',
+  '[data-words~="two"]',
+  '[data-dash|="en"]',
+  '[data-testid="TARGET" i]',
+  '[data-testid="TARGET" s]',
+  '[DATA-TESTID]',
+  '[lang]',
+  '[lang="en"]',
+  '[foo]',
+  '[foo="target"]',
+  '[*|foo]',
+  '[*|foo="target"]',
+  '[|foo]',
+  '[data-testid]:not([missing])',
+  'div[data-testid] > span'
+];
+
+describe('internal attribute access', () => {
+  for (const contentType of [
+    'text/html',
+    'application/xhtml+xml',
+    'application/xml'
+  ]) {
+    it(`preserves public matching results in ${contentType}`, () => {
+      const { window } = new JSDOM('<root/>', { contentType });
+      try {
+        const document = window.document;
+        const root = document.documentElement;
+        const element = document.createElementNS(
+          'http://www.w3.org/1999/xhtml',
+          'div'
+        );
+        element.setAttribute('data-testid', 'target');
+        element.setAttribute('data-words', 'one two three');
+        element.setAttribute('data-dash', 'en-US');
+        element.setAttributeNS('urn:one', 'x:foo', 'target');
+        element.setAttributeNS('urn:two', 'foo', 'other');
+        element.setAttributeNS(
+          'http://www.w3.org/XML/1998/namespace',
+          'xml:lang',
+          'en'
+        );
+        element.appendChild(
+          document.createElementNS('http://www.w3.org/1999/xhtml', 'span')
+        );
+        root.appendChild(element);
+        const svg = document.createElementNS(
+          'http://www.w3.org/2000/svg',
+          'svg'
+        );
+        svg.setAttribute('DATA-TESTID', 'target');
+        svg.setAttributeNS('urn:one', 'x:foo', 'target');
+        root.appendChild(svg);
+        const plain = new DOMSelector(window, document);
+        const internal = new DOMSelector(
+          window,
+          idlUtils.implForWrapper(document),
+          { idlUtils, domSymbolTree, getAttributeList }
+        );
+        for (const selector of selectors) {
+          assert.deepEqual(
+            internal.querySelectorAll(selector, idlUtils.implForWrapper(root)),
+            plain.querySelectorAll(selector, root),
+            selector
+          );
+          for (const node of [element, svg]) {
+            assert.equal(
+              internal.matches(selector, idlUtils.implForWrapper(node)),
+              plain.matches(selector, node),
+              selector
+            );
+          }
+        }
+        for (const selector of ['[data-testid="target" z]', '[data-testid=']) {
+          assert.throws(
+            () =>
+              internal.querySelectorAll(
+                selector,
+                idlUtils.implForWrapper(root)
+              ),
+            { name: 'SyntaxError' }
+          );
+        }
+        element.removeAttribute('data-testid');
+        plain.clear();
+        internal.clear();
+        assert.deepEqual(
+          internal.querySelectorAll(
+            '[data-testid]',
+            idlUtils.implForWrapper(root)
+          ),
+          plain.querySelectorAll('[data-testid]', root)
+        );
+      } finally {
+        window.close();
+      }
+    });
+  }
+
+  for (const kind of ['element', 'document', 'fragment', 'shadow']) {
+    it(`preserves presence query order and boundaries in a ${kind} root`, () => {
+      const { window } = new JSDOM('<main/>');
+      try {
+        const document = window.document;
+        const host = document.body.appendChild(
+          document.createElement('section')
+        );
+        const root =
+          kind === 'document'
+            ? document
+            : kind === 'fragment'
+              ? document.createDocumentFragment()
+              : kind === 'shadow'
+                ? host.attachShadow({ mode: 'closed' })
+                : host;
+        const parent = kind === 'document' ? document.body : root;
+        if (kind === 'element') {
+          root.setAttribute('data-testid', 'root');
+        }
+        parent.appendChild(document.createTextNode('text'));
+        parent.appendChild(document.createComment('comment'));
+        const first = parent.appendChild(document.createElement('div'));
+        first.setAttribute('data-testid', 'first');
+        const second = first.appendChild(document.createElement('span'));
+        second.setAttribute('data-testid', 'second');
+        const shadowHost = parent.appendChild(document.createElement('aside'));
+        shadowHost
+          .attachShadow({ mode: 'open' })
+          .appendChild(document.createElement('b'))
+          .setAttribute('data-testid', 'hidden');
+        const plain = new DOMSelector(window, document);
+        const internal = new DOMSelector(
+          window,
+          idlUtils.implForWrapper(document),
+          { idlUtils, domSymbolTree, getAttributeList }
+        );
+        assert.deepEqual(
+          internal.querySelectorAll(
+            '[data-testid]',
+            idlUtils.implForWrapper(root)
+          ),
+          [first, second]
+        );
+        second.remove();
+        internal.clear();
+        plain.clear();
+        assert.deepEqual(
+          internal.querySelectorAll(
+            '[data-testid]',
+            idlUtils.implForWrapper(root)
+          ),
+          plain.querySelectorAll('[data-testid]', root)
+        );
+      } finally {
+        window.close();
+      }
+    });
+  }
+
+  it('accepts readonly attribute records without DOM wrappers', () => {
+    const { window } = new JSDOM(
+      '<main><div data-testid="target"></div></main>'
+    );
+    try {
+      const document = window.document;
+      const root = document.querySelector('main');
+      const element = root.firstElementChild;
+      const attributes = Object.freeze([
+        Object.freeze({
+          name: 'data-testid',
+          value: 'target',
+          namespaceURI: null,
+          localName: 'data-testid'
+        })
+      ]);
+      let reads = 0;
+      const internal = new DOMSelector(
+        window,
+        idlUtils.implForWrapper(document),
+        {
+          idlUtils,
+          getAttributeList(impl) {
+            assert.equal(impl, idlUtils.implForWrapper(element));
+            reads++;
+            return attributes;
+          }
+        }
+      );
+      assert.deepEqual(
+        internal.querySelectorAll(
+          '[data-testid^="tar"]',
+          idlUtils.implForWrapper(root)
+        ),
+        [element]
+      );
+      assert.equal(reads, 1);
+    } finally {
+      window.close();
+    }
+  });
+
+  it('keeps the public attribute-list fallback when no callback is supplied', () => {
+    const { window } = new JSDOM(
+      '<main><div data-testid="target"></div></main>'
+    );
+    try {
+      const document = window.document;
+      const root = document.querySelector('main');
+      const element = root.firstElementChild;
+      const internal = new DOMSelector(
+        window,
+        idlUtils.implForWrapper(document),
+        { idlUtils }
+      );
+      assert.deepEqual(
+        internal.querySelectorAll(
+          '[data-testid^="tar"]',
+          idlUtils.implForWrapper(root)
+        ),
+        [element]
+      );
+      element.setAttribute('data-testid', 'other');
+      internal.clear();
+      assert.deepEqual(
+        internal.querySelectorAll(
+          '[data-testid^="tar"]',
+          idlUtils.implForWrapper(root)
+        ),
+        []
+      );
+    } finally {
+      window.close();
+    }
+  });
+
+  it('uses the current document after adoption', () => {
+    const { window } = new JSDOM('<main/>');
+    try {
+      const html = window.document;
+      const xml = html.implementation.createDocument(null, 'root');
+      const root = html.createElement('section');
+      const child = root.appendChild(html.createElement('div'));
+      child.setAttribute('data-testid', 'target');
+      for (const document of [html, xml, html]) {
+        document.adoptNode(root);
+        const plain = new DOMSelector(window, document);
+        const internal = new DOMSelector(
+          window,
+          idlUtils.implForWrapper(document),
+          { idlUtils, domSymbolTree, getAttributeList }
+        );
+        for (const selector of [
+          '[DATA-TESTID]',
+          '[DATA-TESTID="target"]',
+          '[data-testid^="tar"]'
+        ]) {
+          assert.deepEqual(
+            internal.querySelectorAll(selector, idlUtils.implForWrapper(root)),
+            plain.querySelectorAll(selector, root),
+            selector
+          );
+        }
+      }
+    } finally {
+      window.close();
+    }
+  });
+
+  it('reads internal attributes without calling overridden public accessors', () => {
+    const { window } = new JSDOM(
+      '<main><div data-testid="target"></div></main>'
+    );
+    try {
+      const document = window.document;
+      const root = document.querySelector('main');
+      const element = root.firstElementChild;
+      const internal = new DOMSelector(
+        window,
+        idlUtils.implForWrapper(document),
+        { idlUtils, domSymbolTree, getAttributeList }
+      );
+      const fail = () => {
+        throw new Error('public attribute access');
+      };
+      for (const name of [
+        'hasAttribute',
+        'getAttribute',
+        'getAttributeNames',
+        'hasAttributeNS'
+      ]) {
+        element[name] = fail;
+      }
+      Object.defineProperty(element, 'attributes', { get: fail });
+      for (const selector of [
+        '[data-testid]',
+        '[data-testid="target"]',
+        '[data-testid^="tar"]'
+      ]) {
+        assert.deepEqual(
+          internal.querySelectorAll(selector, idlUtils.implForWrapper(root)),
+          [element]
+        );
+      }
+    } finally {
+      window.close();
+    }
+  });
+});

--- a/test/utility.test.js
+++ b/test/utility.test.js
@@ -5,6 +5,8 @@
 /* api */
 import { strict as assert } from 'node:assert';
 import { JSDOM } from 'jsdom';
+import idlUtils from 'jsdom/lib/generated/idl/utils.js';
+import internalConstants from 'jsdom/lib/jsdom/living/helpers/internal-constants.js';
 import { afterEach, beforeEach, describe, it } from 'mocha';
 
 /* test */
@@ -2656,6 +2658,87 @@ describe('utility functions', () => {
 
   describe('findBySimpleAttribute', () => {
     const func = util.findBySimpleAttribute;
+
+    it('should wrap only matching descendants without creating a TreeWalker', () => {
+      const root = document.createElement('div');
+      root.setAttribute('hidden', '');
+      root.innerHTML =
+        'text<!-- comment --><div hidden><span></span></div><p><span hidden></span></p>';
+      const first = root.firstElementChild;
+      const second = root.lastElementChild.firstElementChild;
+      const wrapped = [];
+      const utils = {
+        implForWrapper: idlUtils.implForWrapper,
+        wrapperForImpl(impl) {
+          wrapped.push(impl);
+          return idlUtils.wrapperForImpl(impl);
+        }
+      };
+      document.createTreeWalker = () => {
+        assert.fail('should not create a public TreeWalker');
+      };
+      const res = func(
+        '[hidden]',
+        root,
+        utils,
+        internalConstants.domSymbolTree
+      );
+      assert.deepEqual(res, [first, second], 'result');
+      assert.deepEqual(
+        wrapped,
+        [idlUtils.implForWrapper(first), idlUtils.implForWrapper(second)],
+        'only matching descendants are wrapped, in tree order'
+      );
+    });
+
+    it('should use internal attribute methods with a public TreeWalker fallback', () => {
+      const root = document.createElement('div');
+      root.innerHTML = '<div hidden></div><span></span>';
+      const first = root.firstElementChild;
+      let walkers = 0;
+      const createTreeWalker = document.createTreeWalker.bind(document);
+      document.createTreeWalker = (...args) => {
+        walkers++;
+        return createTreeWalker(...args);
+      };
+      for (const child of root.children) {
+        child.hasAttribute = child.getAttributeNames = () => {
+          assert.fail('should use implementation attribute methods');
+        };
+      }
+      const utils = {
+        implForWrapper: idlUtils.implForWrapper,
+        wrapperForImpl() {
+          assert.fail('TreeWalker results are already wrapped');
+        }
+      };
+      assert.deepEqual(func('[hidden]', root, utils), [first], 'result');
+      assert.strictEqual(walkers, 1, 'public TreeWalker fallback');
+    });
+
+    it('should reject unsupported queries before accessing the internal tree', () => {
+      const root = document.createElement('div');
+      const utils = {
+        implForWrapper() {
+          assert.fail('should reject the query before unwrapping');
+        }
+      };
+      const tree = {
+        treeIterator() {
+          assert.fail('should reject the query before traversing');
+        }
+      };
+      for (const selector of [
+        '[lang]',
+        '[hidden=""]',
+        'div[hidden]',
+        '[hidden'
+      ]) {
+        assert.strictEqual(func(selector, root, utils, tree), null, selector);
+      }
+      const xml = document.implementation.createDocument(null, 'root');
+      assert.strictEqual(func('[hidden]', xml, utils, tree), null, 'XML');
+    });
 
     it('should return null if selector is not a string', () => {
       const root = document.createElement('div');

--- a/types/js/evaluator.d.ts
+++ b/types/js/evaluator.d.ts
@@ -12,7 +12,10 @@ export declare class Evaluator {
     node: Document | DocumentFragment | Element | undefined;
     pseudoElements: any[] | undefined;
     invalidate: boolean | undefined;
-    constructor(window: Window);
+    constructor(window: Window, { idlUtils, getAttributeList }?: {
+        idlUtils?: object;
+        getAttributeList?: import('./matcher.js').GetAttributeList;
+    });
     get eventHandler(): EventHandler;
     get verifyShadowHost(): boolean;
     setup(selector: string, node: Document | DocumentFragment | Element, opt?: {

--- a/types/js/matcher.d.ts
+++ b/types/js/matcher.d.ts
@@ -1,3 +1,10 @@
+export type AttributeData = {
+    name: string;
+    value: string;
+    namespaceURI: string | null;
+    localName: string;
+};
+export type GetAttributeList = (element: object) => readonly AttributeData[];
 export declare const matchPseudoElementSelector: (astName: string, astType: string, { forgive, globalObject, warn }?: {
     forgive?: boolean;
     globalObject?: object;
@@ -16,7 +23,7 @@ export declare const matchAttributeSelector: (ast: import('css-tree').CssNode, n
     check?: boolean;
     forgive?: boolean;
     globalObject?: object;
-}) => boolean;
+}, impl?: object, getAttributeList?: GetAttributeList) => boolean;
 export declare const matchTypeSelector: (ast: import('css-tree').CssNode, node: Element, { check, forgive, globalObject }?: {
     check?: boolean;
     forgive?: boolean;

--- a/types/js/utility.d.ts
+++ b/types/js/utility.d.ts
@@ -25,7 +25,7 @@ export declare const populateHasAllowlist: (current: Element, list: WeakSet<Elem
 export declare const collectAllDescendants: (node: Document | DocumentFragment | Element, document: Document) => Array<Element>;
 export declare const hasAttributeLocalName: (node: Element, name: string) => boolean;
 export declare const findByExactIdAttribute: (selector: string, node: Document | DocumentFragment | Element) => Element | null | undefined;
-export declare const findBySimpleAttribute: (selector: string, node: Document | DocumentFragment | Element) => Array<Element> | null;
+export declare const findBySimpleAttribute: (selector: string, node: Document | DocumentFragment | Element, idlUtils?: object, domSymbolTree?: object) => Array<Element> | null;
 export declare const getTraversalStrategy: (branch: Array<object>, targetType: string, hasScope: boolean, scoped: boolean) => object;
 export declare const canUseFastIdSearch: (node: Element, root: Document | DocumentFragment | Element) => boolean;
 export declare const canUseFastClassSearch: (node: Document | DocumentFragment | Element) => boolean;


### PR DESCRIPTION
Speed up attribute selectors by reading jsdom’s internal nodes and attributes directly. Results still contain the usual DOM elements. Includes an optional attribute-list callback used by the [jsdom follow-up](https://github.com/jsdom/jsdom/pull/4297).

Look up elements by attribute value after changing an unrelated attribute. Each lookup queries `[data-testid]` and filters the results for a different value. Batches of 1, 5, or 20 lookups take 20–24% less time with this change.

| Rows | Lookups per DOM change | Before | This PR | Less time |
| ---: | ---: | ---: | ---: | ---: |
| 20 | 1 | 13.37 µs | 10.66 µs | 20% |
| 20 | 5 | 63.44 µs | 49.45 µs | 22% |
| 20 | 20 | 246.39 µs | 196.53 µs | 20% |
| 250 | 1 | 152.46 µs | 117.97 µs | 23% |
| 250 | 5 | 755.99 µs | 576.64 µs | 24% |
| 250 | 20 | 3041.83 µs | 2328.42 µs | 23% |

Only dom-selector changes in this comparison; jsdom is unchanged. Means of two runs in opposite order, Node 26.8.1 on an Apple M4 Max. Both versions include the same separate CSS optimization.

<details>
<summary>What each part improves</summary>

Each comparison adds just the change named in the table. Median of four runs in separate processes, with execution order varied. Each query follows an unrelated attribute change; matching caches are cleared. Same machine and Node version as above, with 300 ms warmup and 800 ms measurement per case.

| Rows | Change | Query | Before | After |
| ---: | --- | --- | ---: | ---: |
| 20 | Read attributes directly | `[data-testid="row-19"]` | 12.31 µs | 7.94 µs |
| 20 | Walk internal nodes | `[data-testid]` | 3.73 µs | 3.74 µs |
| 20 | Read attribute lists directly | `[data-testid^="row-"]` | 43.35 µs | 7.84 µs |
| 250 | Read attributes directly | `[data-testid="row-249"]` | 215.89 µs | 123.76 µs |
| 250 | Walk internal nodes | `[data-testid]` | 56.67 µs | 44.10 µs |
| 250 | Read attribute lists directly | `[data-testid^="row-"]` | 567.67 µs | 108.79 µs |

Walking internal nodes was neutral at 20 rows and faster at 250 rows.

</details>

<details>
<summary>Other workloads</summary>

From the earlier two-run comparison of baseline and both changes together.

| Workload | Before | After |
| --- | ---: | ---: |
| `.row > span` | 53.30 µs | 53.24 µs |
| Parse 250 rows | 2.760 ms | 2.760 ms |
| Event dispatch | 6.62 µs | 6.68 µs |
| MutationObserver, 50 additions | 94.19 µs | 96.18 µs |
| Base UI form mount + unmount | 2.228 ms | 2.115 ms |

The full form did not show a repeatable improvement: baseline runs ranged from 2.05 to 2.40 ms. I wouldn't claim a form speedup from this.

</details>
